### PR TITLE
Fix typo in main.cpp comment

### DIFF
--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -17,7 +17,7 @@
 // SDL
 #include <SDL2/SDL.h>
 
-// E131Sever
+// E131Server
 #include <E131Server.h>
 
 // MoodyCamel


### PR DESCRIPTION
## Summary
- fix a comment about the E131 server in `main.cpp`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68816d09573c832dacb3043cac85f431