### PR TITLE
CI: cap artifact retention + bump actions off Node 20

### DIFF
--- a/.github/workflows/amd64.yml
+++ b/.github/workflows/amd64.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Login to Docker Hub

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: buildjet-16vcpu-ubuntu-2204-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Login to Docker Hub

--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -17,7 +17,7 @@ jobs:
           - buildjet-16vcpu-ubuntu-2204-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -31,7 +31,11 @@ jobs:
         run: mkdir ${{github.workspace}}/package/ && docker cp temp-container:/package/ ${{github.workspace}}/
 
       - name: Save artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: creature-server-package-${{ matrix.os }}
           path: ${{github.workspace}}/package/
+          # 7-day retention so build artifacts don't pile up against the
+          # account-level Actions storage quota. Long enough to grab a
+          # package off a recent commit; older commits should be rebuilt.
+          retention-days: 7


### PR DESCRIPTION
Two CI hygiene fixes:

## 1. Cap artifact retention

The `Save artifact` step in `debian-package.yml` was using GHA's default
90-day retention. Across the two-arch BuildJet matrix (8vcpu amd64 +
16vcpu arm64), this had piled up **452 artifacts (~3.2 GB)** against the
account-level Actions storage quota. (All cleaned up locally a few minutes
ago — this PR keeps it from happening again.)

Adds `retention-days: 7`. Same pattern as conops, creature-listener
(#1), creature-console (#2). 7 days is enough to grab a package off a
recent commit; older commits should be rebuilt.

## 2. Bump actions off Node.js 20

GHA started warning that `actions/checkout@v4` and
`actions/upload-artifact@v4` run on Node.js 20 — scheduled to be
forced to Node 24 on 2026-06-02 and removed entirely on 2026-09-16.

Pinned to current majors that ship on Node 24:
- `actions/checkout` v4 → v6 (latest v6.0.2)
- `actions/upload-artifact` v4 → v7 (latest v7.0.1, only intentional
  change is the additive `archive: false` flag — existing `with:` keys
  unchanged)

Files touched: `amd64.yml`, `arm64.yml`, `debian-package.yml` (the
last one gets both bumps; the first two only use `checkout`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)