### PR TITLE
Migrate remaining controllers to runEndpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 
 project(creature-server
-        VERSION "3.13.1"
+        VERSION "3.13.2"
         DESCRIPTION "Server for April's Creatures"
         HOMEPAGE_URL https://github.com/opsnlops/creature-server
         LANGUAGES C CXX)

--- a/src/server/ws/controller/AnimationController.h
+++ b/src/server/ws/controller/AnimationController.h
@@ -17,6 +17,7 @@
 #include "server/jobs/JobManager.h"
 #include "server/jobs/JobWorker.h"
 #include "server/metrics/counters.h"
+#include "server/ws/controller/ControllerUtils.h"
 #include "server/ws/dto/AdHocAnimationDto.h"
 #include "server/ws/dto/CreateAdHocAnimationRequestDto.h"
 #include "server/ws/dto/JobCreatedDto.h"
@@ -25,13 +26,11 @@
 #include "server/ws/dto/TriggerAdHocAnimationRequestDto.h"
 #include "server/ws/service/AnimationService.h"
 #include "server/ws/service/CreatureService.h"
-#include "server/ws/controller/ControllerUtils.h"
 #include "util/cache.h"
 #include "util/websocketUtils.h"
 #include <nlohmann/json.hpp>
 
 namespace creatures {
-extern std::shared_ptr<ObservabilityManager> observability;
 extern std::shared_ptr<SessionManager> sessionManager;
 extern std::shared_ptr<Configuration> config;
 extern std::shared_ptr<jobs::JobManager> jobManager;
@@ -66,30 +65,17 @@ class AnimationController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<StatusDto>>(Status::CODE_404, "application/json; charset=utf-8");
         info->addResponse<Object<StatusDto>>(Status::CODE_500, "application/json; charset=utf-8");
     }
-    ENDPOINT("GET", "api/v1/animation", listAllAnimations,
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        // Create a trace span for this request
-        auto span = creatures::observability->createRequestSpan("GET /api/v1/animation", "GET", "api/v1/animation",
-                                                                extractTraceparent(request));
-        addHttpRequestAttributes(span, request); // Add HTTP attributes
-
+    ENDPOINT("GET", "api/v1/animation", listAllAnimations, REQUEST(std::shared_ptr<IncomingRequest>, request)) {
         debug("REST call to listAllAnimations");
-        creatures::metrics->incrementRestRequestsProcessed();
-
-        if (span) {
-            span->setAttribute("endpoint.name", "listAllAnimations");
-            span->setAttribute("controller.name", "AnimationController");
-        }
-
-        auto result = m_animationService.listAllAnimations(std::move(span));
-
-        // Record success metrics in the span
-        if (span) {
-            span->setAttribute("animations.count", static_cast<int64_t>(result->count));
-            span->setHttpStatus(200);
-        }
-
-        return createDtoResponse(Status::CODE_200, result);
+        return runEndpoint("GET /api/v1/animation", "GET", "api/v1/animation", "listAllAnimations",
+                           "AnimationController", request, [&](const auto &span) {
+                               auto result = m_animationService.listAllAnimations(span);
+                               if (span) {
+                                   span->setAttribute("animations.count", static_cast<int64_t>(result->count));
+                                   span->setHttpStatus(200);
+                               }
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(listAdHocAnimations) {
@@ -99,25 +85,16 @@ class AnimationController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<StatusDto>>(Status::CODE_500, "application/json; charset=utf-8");
     }
     ENDPOINT("GET", "api/v1/animation/ad-hoc", listAdHocAnimations,
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        auto span = creatures::observability->createRequestSpan("GET /api/v1/animation/ad-hoc", "GET",
-                                                                "api/v1/animation/ad-hoc",
-                                                                extractTraceparent(request));
-        addHttpRequestAttributes(span, request);
-
-        creatures::metrics->incrementRestRequestsProcessed();
-
-        if (span) {
-            span->setAttribute("endpoint.name", "listAdHocAnimations");
-            span->setAttribute("controller.name", "AnimationController");
-        }
-
-        auto result = m_animationService.listAdHocAnimations(span);
-        if (span) {
-            span->setHttpStatus(200);
-            span->setAttribute("adhoc.count", static_cast<int64_t>(result->count));
-        }
-        return createDtoResponse(Status::CODE_200, result);
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint("GET /api/v1/animation/ad-hoc", "GET", "api/v1/animation/ad-hoc", "listAdHocAnimations",
+                           "AnimationController", request, [&](const auto &span) {
+                               auto result = m_animationService.listAdHocAnimations(span);
+                               if (span) {
+                                   span->setAttribute("adhoc.count", static_cast<int64_t>(result->count));
+                                   span->setHttpStatus(200);
+                               }
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(getAdHocAnimation) {
@@ -130,28 +107,19 @@ class AnimationController : public oatpp::web::server::api::ApiController {
         info->pathParams["animationId"].description = "Ad-hoc animation ID";
     }
     ENDPOINT("GET", "api/v1/animation/ad-hoc/{animationId}", getAdHocAnimation, PATH(String, animationId),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        auto span = creatures::observability->createRequestSpan("GET /api/v1/animation/ad-hoc/{animationId}", "GET",
-                                                                "api/v1/animation/ad-hoc/" + std::string(animationId),
-                                                                extractTraceparent(request));
-        addHttpRequestAttributes(span, request);
-
-        creatures::metrics->incrementRestRequestsProcessed();
-
-        if (span) {
-            span->setAttribute("endpoint.name", "getAdHocAnimation");
-            span->setAttribute("controller.name", "AnimationController");
-            span->setAttribute("animation.id", std::string(animationId));
-        }
-
-        auto result = m_animationService.getAdHocAnimation(animationId, span);
-
-        if (span) {
-            span->setAttribute("animation.title", std::string(result->metadata->title));
-            span->setHttpStatus(200);
-        }
-
-        return createDtoResponse(Status::CODE_200, result);
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint("GET /api/v1/animation/ad-hoc/{animationId}", "GET",
+                           "api/v1/animation/ad-hoc/" + std::string(animationId), "getAdHocAnimation",
+                           "AnimationController", request, [&](const auto &span) {
+                               if (span)
+                                   span->setAttribute("animation.id", std::string(animationId));
+                               auto result = m_animationService.getAdHocAnimation(animationId, span);
+                               if (span) {
+                                   span->setAttribute("animation.title", std::string(result->metadata->title));
+                                   span->setHttpStatus(200);
+                               }
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(getAnimation) {
@@ -164,32 +132,19 @@ class AnimationController : public oatpp::web::server::api::ApiController {
         info->pathParams["animationId"].description = "Animation ID in the form of a MongoDB OID";
     }
     ENDPOINT("GET", "api/v1/animation/{animationId}", getAnimation, PATH(String, animationId),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        // RequestSpan only handles HTTP-level concerns
-        auto span = creatures::observability->createRequestSpan("GET /api/v1/animation/{animationId}", "GET",
-                                                                "api/v1/animation/" + std::string(animationId),
-                                                                extractTraceparent(request));
-        addHttpRequestAttributes(span, request); // Add HTTP attributes
-
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
         debug("get animation by ID via REST API: {}", std::string(animationId));
-        creatures::metrics->incrementRestRequestsProcessed();
-
-        if (span) {
-            span->setAttribute("endpoint.name", "getAnimation");
-            span->setAttribute("controller.name", "AnimationController");
-            span->setAttribute("animation.id", std::string(animationId));
-        }
-
-        // The service call will create its own OperationSpan
-        auto result = m_animationService.getAnimation(animationId, span);
-
-        if (span) {
-            // HTTP handler just cares about HTTP success
-            span->setAttribute("animation.title", std::string(result->metadata->title));
-            span->setHttpStatus(200);
-        }
-
-        return createDtoResponse(Status::CODE_200, result);
+        return runEndpoint("GET /api/v1/animation/{animationId}", "GET", "api/v1/animation/" + std::string(animationId),
+                           "getAnimation", "AnimationController", request, [&](const auto &span) {
+                               if (span)
+                                   span->setAttribute("animation.id", std::string(animationId));
+                               auto result = m_animationService.getAnimation(animationId, span);
+                               if (span) {
+                                   span->setAttribute("animation.title", std::string(result->metadata->title));
+                                   span->setHttpStatus(200);
+                               }
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(generateLipSyncForAnimation) {
@@ -205,107 +160,106 @@ class AnimationController : public oatpp::web::server::api::ApiController {
     }
     ENDPOINT("POST", "api/v1/animation/generate-lipsync", generateLipSyncForAnimation,
              BODY_DTO(Object<creatures::ws::RegenerateLipSyncRequestDto>, requestBody),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        auto span = creatures::observability->createRequestSpan("POST /api/v1/animation/generate-lipsync", "POST",
-                                                                "api/v1/animation/generate-lipsync",
-                                                                extractTraceparent(request));
-        addHttpRequestAttributes(span, request);
-        creatures::metrics->incrementRestRequestsProcessed();
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint(
+            "POST /api/v1/animation/generate-lipsync", "POST", "api/v1/animation/generate-lipsync",
+            "generateLipSyncForAnimation", "AnimationController", request,
+            [&](const auto &span) -> std::shared_ptr<OutgoingResponse> {
+                if (!requestBody || !requestBody->animation_id || requestBody->animation_id->empty()) {
+                    auto response = StatusDto::createShared();
+                    response->status = "error";
+                    response->code = 400;
+                    response->message = "animation_id is required";
+                    if (span) {
+                        span->setAttribute("error.type", "invalid_request");
+                        span->setHttpStatus(400);
+                    }
+                    return createDtoResponse(Status::CODE_400, response);
+                }
 
-        if (!requestBody || !requestBody->animation_id || requestBody->animation_id->empty()) {
-            auto response = StatusDto::createShared();
-            response->status = "error";
-            response->code = 400;
-            response->message = "animation_id is required";
-            if (span) {
-                span->setAttribute("error.type", "invalid_request");
-                span->setHttpStatus(400);
-            }
-            return createDtoResponse(Status::CODE_400, response);
-        }
+                std::string animationId = std::string(requestBody->animation_id);
+                if (span) {
+                    span->setAttribute("animation.id", animationId);
+                }
 
-        std::string animationId = std::string(requestBody->animation_id);
-        if (span) {
-            span->setAttribute("animation.id", animationId);
-        }
+                auto animationLookupSpan =
+                    creatures::observability->createOperationSpan("AnimationController.getAnimation", span);
+                if (animationLookupSpan) {
+                    animationLookupSpan->setAttribute("animation.id", animationId);
+                }
 
-        auto animationLookupSpan =
-            creatures::observability->createOperationSpan("AnimationController.getAnimation", span);
-        if (animationLookupSpan) {
-            animationLookupSpan->setAttribute("animation.id", animationId);
-        }
+                auto animationResult = creatures::db->getAnimation(animationId, animationLookupSpan);
+                if (!animationResult.isSuccess()) {
+                    auto error = animationResult.getError().value();
+                    auto response = StatusDto::createShared();
+                    response->status = "error";
+                    response->message = error.getMessage();
+                    Status status = Status::CODE_500;
+                    switch (error.getCode()) {
+                    case ServerError::NotFound:
+                        status = Status::CODE_404;
+                        break;
+                    case ServerError::InvalidData:
+                        status = Status::CODE_400;
+                        break;
+                    default:
+                        status = Status::CODE_500;
+                        break;
+                    }
+                    response->code = status.code;
+                    if (span) {
+                        span->setHttpStatus(status.code);
+                        span->setAttribute("error.type", "animation_lookup_failed");
+                    }
+                    return createDtoResponse(status, response);
+                }
+                auto animation = animationResult.getValue().value();
 
-        auto animationResult = creatures::db->getAnimation(animationId, animationLookupSpan);
-        if (!animationResult.isSuccess()) {
-            auto error = animationResult.getError().value();
-            auto response = StatusDto::createShared();
-            response->status = "error";
-            response->message = error.getMessage();
-            Status status = Status::CODE_500;
-            switch (error.getCode()) {
-            case ServerError::NotFound:
-                status = Status::CODE_404;
-                break;
-            case ServerError::InvalidData:
-                status = Status::CODE_400;
-                break;
-            default:
-                status = Status::CODE_500;
-                break;
-            }
-            response->code = status.code;
-            if (span) {
-                span->setHttpStatus(status.code);
-                span->setAttribute("error.type", "animation_lookup_failed");
-            }
-            return createDtoResponse(status, response);
-        }
-        auto animation = animationResult.getValue().value();
+                if (animation.metadata.sound_file.empty()) {
+                    auto response = StatusDto::createShared();
+                    response->status = "error";
+                    response->code = 422;
+                    response->message = "Animation has no sound file configured";
+                    if (span) {
+                        span->setHttpStatus(422);
+                        span->setAttribute("error.type", "missing_sound_file");
+                    }
+                    return createDtoResponse(Status::CODE_422, response);
+                }
 
-        if (animation.metadata.sound_file.empty()) {
-            auto response = StatusDto::createShared();
-            response->status = "error";
-            response->code = 422;
-            response->message = "Animation has no sound file configured";
-            if (span) {
-                span->setHttpStatus(422);
-                span->setAttribute("error.type", "missing_sound_file");
-            }
-            return createDtoResponse(Status::CODE_422, response);
-        }
+                if (!animation.metadata.multitrack_audio) {
+                    auto response = StatusDto::createShared();
+                    response->status = "error";
+                    response->code = 422;
+                    response->message = "Animation audio must be multitrack to generate lip sync";
+                    if (span) {
+                        span->setHttpStatus(422);
+                        span->setAttribute("error.type", "audio_not_multitrack");
+                    }
+                    return createDtoResponse(Status::CODE_422, response);
+                }
 
-        if (!animation.metadata.multitrack_audio) {
-            auto response = StatusDto::createShared();
-            response->status = "error";
-            response->code = 422;
-            response->message = "Animation audio must be multitrack to generate lip sync";
-            if (span) {
-                span->setHttpStatus(422);
-                span->setAttribute("error.type", "audio_not_multitrack");
-            }
-            return createDtoResponse(Status::CODE_422, response);
-        }
+                nlohmann::json jobDetails;
+                jobDetails["animation_id"] = animationId;
 
-        nlohmann::json jobDetails;
-        jobDetails["animation_id"] = animationId;
+                auto jobId = creatures::jobManager->createJob(creatures::jobs::JobType::AnimationLipSync,
+                                                              jobDetails.dump(), span);
+                creatures::jobWorker->queueJob(jobId);
 
-        auto jobId =
-            creatures::jobManager->createJob(creatures::jobs::JobType::AnimationLipSync, jobDetails.dump(), span);
-        creatures::jobWorker->queueJob(jobId);
+                auto response = JobCreatedDto::createShared();
+                response->job_id = jobId;
+                response->job_type = "animation-lip-sync";
+                response->message = fmt::format(
+                    "Lip sync generation job created for animation {}. Monitor job-progress events for updates.",
+                    animationId);
 
-        auto response = JobCreatedDto::createShared();
-        response->job_id = jobId;
-        response->job_type = "animation-lip-sync";
-        response->message = fmt::format(
-            "Lip sync generation job created for animation {}. Monitor job-progress events for updates.", animationId);
+                if (span) {
+                    span->setHttpStatus(202);
+                    span->setAttribute("job.id", jobId);
+                }
 
-        if (span) {
-            span->setHttpStatus(202);
-            span->setAttribute("job.id", jobId);
-            span->setAttribute("success", true);
-        }
-
-        return createDtoResponse(Status::CODE_202, response);
+                return createDtoResponse(Status::CODE_202, response);
+            });
     }
 
     ENDPOINT_INFO(upsertAnimation) {
@@ -315,48 +269,25 @@ class AnimationController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<StatusDto>>(Status::CODE_400, "application/json; charset=utf-8");
         info->addResponse<Object<StatusDto>>(Status::CODE_500, "application/json; charset=utf-8");
     }
-    ENDPOINT("POST", "api/v1/animation", upsertAnimation,
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        // Span for the upsert operation
-        auto span = creatures::observability->createRequestSpan("POST /api/v1/animation", "POST", "api/v1/animation",
-                                                                extractTraceparent(request));
-        addHttpRequestAttributes(span, request); // Add HTTP attributes
-
+    ENDPOINT("POST", "api/v1/animation", upsertAnimation, REQUEST(std::shared_ptr<IncomingRequest>, request)) {
         debug("new animation uploaded via REST API");
-        creatures::metrics->incrementRestRequestsProcessed();
-
-        try {
-            auto requestAsString = std::string(request->readBodyToString());
-            trace("request was: {}", requestAsString);
-
-            if (span) {
-                span->setAttribute("endpoint.name", "upsertAnimation");
-                span->setAttribute("controller.name", "AnimationController");
-                span->setAttribute("request.body_size", static_cast<int64_t>(requestAsString.length()));
-            }
-
-            auto result = m_animationService.upsertAnimation(requestAsString, span);
-
-            if (span) {
-                span->setAttribute("animation.id", std::string(result->id));
-                span->setAttribute("animation.title", std::string(result->metadata->title));
-                span->setHttpStatus(200);
-            }
-
-            // Schedule cache invalidation (this could be traced too!)
-            scheduleCacheInvalidationEvent(CACHE_INVALIDATION_DELAY_TIME, CacheType::Animation);
-
-            return createDtoResponse(Status::CODE_200, result);
-
-        } catch (const std::exception &ex) {
-            if (span) {
-                span->recordException(ex);
-                span->setHttpStatus(500);
-            }
-
-            error("Exception in upsertAnimation: {}", ex.what());
-            throw;
-        }
+        return runEndpoint("POST /api/v1/animation", "POST", "api/v1/animation", "upsertAnimation",
+                           "AnimationController", request, [&](const auto &span) {
+                               auto requestAsString = std::string(request->readBodyToString());
+                               trace("request was: {}", requestAsString);
+                               if (span) {
+                                   span->setAttribute("request.body_size",
+                                                      static_cast<int64_t>(requestAsString.length()));
+                               }
+                               auto result = m_animationService.upsertAnimation(requestAsString, span);
+                               if (span) {
+                                   span->setAttribute("animation.id", std::string(result->id));
+                                   span->setAttribute("animation.title", std::string(result->metadata->title));
+                                   span->setHttpStatus(200);
+                               }
+                               scheduleCacheInvalidationEvent(CACHE_INVALIDATION_DELAY_TIME, CacheType::Animation);
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(deleteAnimation) {
@@ -369,44 +300,24 @@ class AnimationController : public oatpp::web::server::api::ApiController {
         info->pathParams["animationId"].description = "Animation ID";
     }
     ENDPOINT("DELETE", "api/v1/animation/{animationId}", deleteAnimation, PATH(String, animationId),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        auto span =
-            creatures::observability->createRequestSpan("DELETE /api/v1/animation/{animationId}", "DELETE",
-                                                        fmt::format("api/v1/animation/{}", std::string(animationId)),
-                                                        extractTraceparent(request));
-        addHttpRequestAttributes(span, request);
-
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
         debug("delete animation via REST API: {}", std::string(animationId));
-        creatures::metrics->incrementRestRequestsProcessed();
-
-        if (span) {
-            span->setAttribute("endpoint.name", "deleteAnimation");
-            span->setAttribute("controller.name", "AnimationController");
-            span->setAttribute("animation.id", std::string(animationId));
-        }
-
-        try {
-            auto result = m_animationService.deleteAnimation(animationId, span);
-
-            if (span) {
-                span->setHttpStatus(200);
-            }
-
-            scheduleCacheInvalidationEvent(CACHE_INVALIDATION_DELAY_TIME, CacheType::Animation);
-            auto broadcastResult = broadcastCacheInvalidationToAllClients(CacheType::Animation);
-            if (!broadcastResult.isSuccess()) {
-                warn("Failed to broadcast animation cache invalidation: {}", broadcastResult.getError()->getMessage());
-            }
-            return createDtoResponse(Status::CODE_200, result);
-        } catch (const std::exception &ex) {
-            if (span) {
-                span->recordException(ex);
-                span->setHttpStatus(500);
-            }
-
-            error("Exception in deleteAnimation: {}", ex.what());
-            throw;
-        }
+        return runEndpoint("DELETE /api/v1/animation/{animationId}", "DELETE",
+                           fmt::format("api/v1/animation/{}", std::string(animationId)), "deleteAnimation",
+                           "AnimationController", request, [&](const auto &span) {
+                               if (span)
+                                   span->setAttribute("animation.id", std::string(animationId));
+                               auto result = m_animationService.deleteAnimation(animationId, span);
+                               if (span)
+                                   span->setHttpStatus(200);
+                               scheduleCacheInvalidationEvent(CACHE_INVALIDATION_DELAY_TIME, CacheType::Animation);
+                               auto broadcastResult = broadcastCacheInvalidationToAllClients(CacheType::Animation);
+                               if (!broadcastResult.isSuccess()) {
+                                   warn("Failed to broadcast animation cache invalidation: {}",
+                                        broadcastResult.getError()->getMessage());
+                               }
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(playStoredAnimation) {
@@ -418,58 +329,37 @@ class AnimationController : public oatpp::web::server::api::ApiController {
     }
     ENDPOINT("POST", "api/v1/animation/play", playStoredAnimation,
              BODY_DTO(Object<creatures::ws::PlayAnimationRequestDto>, requestBody),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        // The most exciting span - playing an animation!
-        auto span = creatures::observability ? creatures::observability->createRequestSpan(
-                                                   "POST /api/v1/animation/play", "POST", "api/v1/animation/play",
-                                                   extractTraceparent(request))
-                                             : nullptr;
-        addHttpRequestAttributes(span, request); // Add HTTP attributes
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint("POST /api/v1/animation/play", "POST", "api/v1/animation/play", "playStoredAnimation",
+                           "AnimationController", request, [&](const auto &span) {
+                               if (!creatures::config || !creatures::db) {
+                                   auto result = creatures::ws::StatusDto::createShared();
+                                   result->status = "error";
+                                   result->code = 500;
+                                   result->message = "Animation play unavailable: server dependencies missing";
+                                   if (span) {
+                                       span->setAttribute("error.type", "missing_dependencies");
+                                       span->setHttpStatus(500);
+                                   }
+                                   return createDtoResponse(Status::CODE_500, result);
+                               }
 
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
+                               if (span) {
+                                   span->setAttribute("animation.id", std::string(requestBody->animation_id));
+                                   span->setAttribute("universe", static_cast<int64_t>(requestBody->universe));
+                                   span->setAttribute("reason", "play");
+                               }
 
-        if (!creatures::config || !creatures::db) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 500;
-            result->message = "Animation play unavailable: server dependencies missing";
-            if (span) {
-                span->setAttribute("error.type", "missing_dependencies");
-                span->setHttpStatus(500);
-            }
-            return createDtoResponse(Status::CODE_500, result);
-        }
+                               auto result = m_animationService.playStoredAnimation(
+                                   std::string(requestBody->animation_id), requestBody->universe, "play");
 
-        try {
-            if (span) {
-                span->setAttribute("endpoint.name", "playStoredAnimation");
-                span->setAttribute("controller.name", "AnimationController");
-                span->setAttribute("animation.id", std::string(requestBody->animation_id));
-                span->setAttribute("universe", static_cast<int64_t>(requestBody->universe));
-                span->setAttribute("reason", "play");
-            }
+                               if (span) {
+                                   span->setAttribute("result.message", std::string(result->message));
+                                   span->setHttpStatus(200);
+                               }
 
-            auto result = m_animationService.playStoredAnimation(std::string(requestBody->animation_id),
-                                                                 requestBody->universe, "play");
-
-            if (span) {
-                span->setAttribute("result.message", std::string(result->message));
-                span->setHttpStatus(200);
-            }
-
-            return createDtoResponse(Status::CODE_200, result);
-
-        } catch (const std::exception &ex) {
-            if (span) {
-                span->recordException(ex);
-                span->setHttpStatus(500);
-            }
-
-            error("Exception in playStoredAnimation: {}", ex.what());
-            throw;
-        }
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(interruptAnimation) {
@@ -484,116 +374,99 @@ class AnimationController : public oatpp::web::server::api::ApiController {
     }
     ENDPOINT("POST", "api/v1/animation/interrupt", interruptAnimation,
              BODY_DTO(Object<creatures::ws::PlayAnimationRequestDto>, requestBody),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        auto span = creatures::observability
-                        ? creatures::observability->createRequestSpan("POST /api/v1/animation/interrupt", "POST",
-                                                                      "api/v1/animation/interrupt",
-                                                                      extractTraceparent(request))
-                        : nullptr;
-        addHttpRequestAttributes(span, request);
-
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
-
-        if (!creatures::config || !creatures::sessionManager) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 500;
-            result->message = "Animation interrupt unavailable: server dependencies missing";
-            if (span) {
-                span->setAttribute("error.type", "missing_dependencies");
-                span->setHttpStatus(500);
-            }
-            return createDtoResponse(Status::CODE_500, result);
-        }
-
-        // Check if cooperative scheduler is enabled
-        if (creatures::config->getAnimationSchedulerType() !=
-            creatures::Configuration::AnimationSchedulerType::Cooperative) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 400;
-            result->message =
-                "Animation interrupts require the cooperative scheduler. Start server with --scheduler cooperative";
-
-            if (span) {
-                span->setAttribute("error.type", "scheduler_not_supported");
-                span->setAttribute("error.message", std::string(result->message));
-                span->setAttribute("scheduler_type", "legacy");
-                span->setHttpStatus(400);
-            }
-
-            error("Interrupt API called with legacy scheduler enabled");
-            return createDtoResponse(Status::CODE_400, result);
-        }
-
-        try {
-            if (span) {
-                span->setAttribute("endpoint.name", "interruptAnimation");
-                span->setAttribute("controller.name", "AnimationController");
-                span->setAttribute("animation.id", std::string(requestBody->animation_id));
-                span->setAttribute("universe", static_cast<int64_t>(requestBody->universe));
-                span->setAttribute("resume_playlist", static_cast<bool>(requestBody->resumePlaylist));
-            }
-
-            bool shouldResume = requestBody->resumePlaylist ? true : false;
-            info("REST API: interrupting universe {} with animation {} (resume: {})",
-                 static_cast<uint32_t>(requestBody->universe), std::string(requestBody->animation_id), shouldResume);
-
-            // Get the animation from the database
-            auto animationDto = m_animationService.getAnimation(requestBody->animation_id, span);
-
-            // Convert from oatpp DTO to internal model
-            std::shared_ptr<AnimationDto> animationDtoPtr(animationDto.get(),
-                                                          [](AnimationDto *) {}); // Non-owning shared_ptr
-            auto animation = convertFromDto(animationDtoPtr);
-
-            // Use SessionManager to interrupt
-            auto sessionResult =
-                creatures::sessionManager->interrupt(requestBody->universe, animation, shouldResume, span);
-
-            if (!sessionResult.isSuccess()) {
-                auto errorMsg = sessionResult.getError()->getMessage();
-                error("Failed to interrupt animation: {}", errorMsg);
-
-                if (span) {
-                    span->setAttribute("error.message", errorMsg);
-                    span->setHttpStatus(500);
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint(
+            "POST /api/v1/animation/interrupt", "POST", "api/v1/animation/interrupt", "interruptAnimation",
+            "AnimationController", request, [&](const auto &span) -> std::shared_ptr<OutgoingResponse> {
+                if (!creatures::config || !creatures::sessionManager) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 500;
+                    result->message = "Animation interrupt unavailable: server dependencies missing";
+                    if (span) {
+                        span->setAttribute("error.type", "missing_dependencies");
+                        span->setHttpStatus(500);
+                    }
+                    return createDtoResponse(Status::CODE_500, result);
                 }
 
-                auto result = creatures::ws::StatusDto::createShared();
-                result->status = "error";
-                result->code = 500;
-                result->message = errorMsg.c_str();
+                // Check if cooperative scheduler is enabled
+                if (creatures::config->getAnimationSchedulerType() !=
+                    creatures::Configuration::AnimationSchedulerType::Cooperative) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 400;
+                    result->message = "Animation interrupts require the cooperative scheduler. Start server with "
+                                      "--scheduler cooperative";
 
-                return createDtoResponse(Status::CODE_500, result);
-            }
+                    if (span) {
+                        span->setAttribute("error.type", "scheduler_not_supported");
+                        span->setAttribute("error.message", std::string(result->message));
+                        span->setAttribute("scheduler_type", "legacy");
+                        span->setHttpStatus(400);
+                    }
 
-            // Success!
-            if (span) {
-                span->setAttribute("result.success", true);
-                span->setHttpStatus(200);
-                span->setAttribute("session.id", sessionResult.getValue().value()->getSessionId());
-            }
+                    error("Interrupt API called with legacy scheduler enabled");
+                    return createDtoResponse(Status::CODE_400, result);
+                }
 
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "success";
-            result->code = 200;
-            result->message = "Animation interrupt scheduled successfully";
-            result->session_id = sessionResult.getValue().value()->getSessionId().c_str();
+                {
+                    if (span) {
+                        span->setAttribute("animation.id", std::string(requestBody->animation_id));
+                        span->setAttribute("universe", static_cast<int64_t>(requestBody->universe));
+                        span->setAttribute("resume_playlist", static_cast<bool>(requestBody->resumePlaylist));
+                    }
 
-            return createDtoResponse(Status::CODE_200, result);
+                    bool shouldResume = requestBody->resumePlaylist ? true : false;
+                    info("REST API: interrupting universe {} with animation {} (resume: {})",
+                         static_cast<uint32_t>(requestBody->universe), std::string(requestBody->animation_id),
+                         shouldResume);
 
-        } catch (const std::exception &ex) {
-            if (span) {
-                span->recordException(ex);
-                span->setHttpStatus(500);
-            }
+                    // Get the animation from the database
+                    auto animationDto = m_animationService.getAnimation(requestBody->animation_id, span);
 
-            error("Exception in interruptAnimation: {}", ex.what());
-            throw;
-        }
+                    // Convert from oatpp DTO to internal model
+                    std::shared_ptr<AnimationDto> animationDtoPtr(animationDto.get(),
+                                                                  [](AnimationDto *) {}); // Non-owning shared_ptr
+                    auto animation = convertFromDto(animationDtoPtr);
+
+                    // Use SessionManager to interrupt
+                    auto sessionResult =
+                        creatures::sessionManager->interrupt(requestBody->universe, animation, shouldResume, span);
+
+                    if (!sessionResult.isSuccess()) {
+                        auto errorMsg = sessionResult.getError()->getMessage();
+                        error("Failed to interrupt animation: {}", errorMsg);
+
+                        if (span) {
+                            span->setAttribute("error.message", errorMsg);
+                            span->setHttpStatus(500);
+                        }
+
+                        auto result = creatures::ws::StatusDto::createShared();
+                        result->status = "error";
+                        result->code = 500;
+                        result->message = errorMsg.c_str();
+
+                        return createDtoResponse(Status::CODE_500, result);
+                    }
+
+                    // Success!
+                    if (span) {
+                        span->setAttribute("result.success", true);
+                        span->setHttpStatus(200);
+                        span->setAttribute("session.id", sessionResult.getValue().value()->getSessionId());
+                    }
+
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "success";
+                    result->code = 200;
+                    result->message = "Animation interrupt scheduled successfully";
+                    result->session_id = sessionResult.getValue().value()->getSessionId().c_str();
+
+                    return createDtoResponse(Status::CODE_200, result);
+                }
+            });
     }
 
     ENDPOINT_INFO(createAdHocAnimation) {
@@ -607,9 +480,10 @@ class AnimationController : public oatpp::web::server::api::ApiController {
     }
     ENDPOINT("POST", "api/v1/animation/ad-hoc", createAdHocAnimation,
              BODY_DTO(Object<creatures::ws::CreateAdHocAnimationRequestDto>, requestBody),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
         return handleAdHocAnimationRequest(requestBody, request, creatures::jobs::JobType::AdHocSpeech, true,
-                                           "POST /api/v1/animation/ad-hoc", "api/v1/animation/ad-hoc");
+                                           "POST /api/v1/animation/ad-hoc", "api/v1/animation/ad-hoc",
+                                           "createAdHocAnimation");
     }
 
     ENDPOINT_INFO(prepareAdHocAnimation) {
@@ -624,9 +498,10 @@ class AnimationController : public oatpp::web::server::api::ApiController {
     }
     ENDPOINT("POST", "api/v1/animation/ad-hoc/prepare", prepareAdHocAnimation,
              BODY_DTO(Object<creatures::ws::CreateAdHocAnimationRequestDto>, requestBody),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
         return handleAdHocAnimationRequest(requestBody, request, creatures::jobs::JobType::AdHocSpeechPrepare, false,
-                                           "POST /api/v1/animation/ad-hoc/prepare", "api/v1/animation/ad-hoc/prepare");
+                                           "POST /api/v1/animation/ad-hoc/prepare", "api/v1/animation/ad-hoc/prepare",
+                                           "prepareAdHocAnimation");
     }
 
     ENDPOINT_INFO(playPreparedAdHocAnimation) {
@@ -643,207 +518,204 @@ class AnimationController : public oatpp::web::server::api::ApiController {
     }
     ENDPOINT("POST", "api/v1/animation/ad-hoc/play", playPreparedAdHocAnimation,
              BODY_DTO(Object<creatures::ws::TriggerAdHocAnimationRequestDto>, requestBody),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        auto span = creatures::observability
-                        ? creatures::observability->createRequestSpan("POST /api/v1/animation/ad-hoc/play", "POST",
-                                                                      "api/v1/animation/ad-hoc/play",
-                                                                      extractTraceparent(request))
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint(
+            "POST /api/v1/animation/ad-hoc/play", "POST", "api/v1/animation/ad-hoc/play", "playPreparedAdHocAnimation",
+            "AnimationController", request, [&](const auto &span) -> std::shared_ptr<OutgoingResponse> {
+                if (!creatures::config || !creatures::db || !creatures::sessionManager ||
+                    !creatures::creatureUniverseMap) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 500;
+                    result->message = "Ad-hoc play unavailable: server dependencies missing";
+                    if (span) {
+                        span->setAttribute("error.type", "missing_dependencies");
+                        span->setHttpStatus(500);
+                    }
+                    return createDtoResponse(Status::CODE_500, result);
+                }
+
+                if (creatures::config->getAnimationSchedulerType() !=
+                    creatures::Configuration::AnimationSchedulerType::Cooperative) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 400;
+                    result->message = "Ad-hoc speech requires the cooperative scheduler (--scheduler cooperative)";
+                    if (span) {
+                        span->setAttribute("error.type", "scheduler_not_supported");
+                        span->setHttpStatus(400);
+                    }
+                    return createDtoResponse(Status::CODE_400, result);
+                }
+
+                auto animationId = requestBody->animation_id ? std::string(requestBody->animation_id) : "";
+                bool resumePlaylist =
+                    requestBody->resume_playlist ? static_cast<bool>(requestBody->resume_playlist) : true;
+
+                if (span) {
+                    span->setAttribute("animation.id", animationId);
+                    span->setAttribute("resume_playlist", resumePlaylist);
+                }
+
+                if (animationId.empty()) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 400;
+                    result->message = "animation_id is required";
+                    if (span) {
+                        span->setAttribute("error.type", "invalid_request");
+                        span->setHttpStatus(400);
+                    }
+                    return createDtoResponse(Status::CODE_400, result);
+                }
+
+                auto animationLookupSpan =
+                    creatures::observability
+                        ? creatures::observability->createOperationSpan("AnimationController.getAdHocAnimation", span)
                         : nullptr;
-        addHttpRequestAttributes(span, request);
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
+                if (animationLookupSpan) {
+                    animationLookupSpan->setAttribute("animation.id", animationId);
+                }
 
-        if (!creatures::config || !creatures::db || !creatures::sessionManager || !creatures::creatureUniverseMap) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 500;
-            result->message = "Ad-hoc play unavailable: server dependencies missing";
-            if (span) {
-                span->setAttribute("error.type", "missing_dependencies");
-                span->setHttpStatus(500);
-            }
-            return createDtoResponse(Status::CODE_500, result);
-        }
+                auto animationResult = creatures::db->getAdHocAnimation(animationId, animationLookupSpan);
+                if (!animationResult.isSuccess()) {
+                    auto error = animationResult.getError().value();
+                    auto response = creatures::ws::StatusDto::createShared();
+                    response->status = "error";
+                    response->message = error.getMessage().c_str();
+                    Status status = Status::CODE_500;
+                    switch (error.getCode()) {
+                    case ServerError::NotFound:
+                        status = Status::CODE_404;
+                        break;
+                    case ServerError::InvalidData:
+                        status = Status::CODE_400;
+                        break;
+                    default:
+                        status = Status::CODE_500;
+                        break;
+                    }
+                    response->code = status.code;
+                    if (span) {
+                        span->setHttpStatus(status.code);
+                        span->setAttribute("error.type", "adhoc_animation_lookup_failed");
+                    }
+                    if (animationLookupSpan) {
+                        animationLookupSpan->setError(error.getMessage());
+                    }
+                    return createDtoResponse(status, response);
+                }
 
-        if (creatures::config->getAnimationSchedulerType() !=
-            creatures::Configuration::AnimationSchedulerType::Cooperative) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 400;
-            result->message = "Ad-hoc speech requires the cooperative scheduler (--scheduler cooperative)";
-            if (span) {
-                span->setAttribute("error.type", "scheduler_not_supported");
-                span->setHttpStatus(400);
-            }
-            return createDtoResponse(Status::CODE_400, result);
-        }
+                auto animation = animationResult.getValue().value();
+                if (animationLookupSpan) {
+                    animationLookupSpan->setSuccess();
+                }
+                if (animation.tracks.empty()) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 422;
+                    result->message = "Prepared animation has no tracks";
+                    if (span) {
+                        span->setAttribute("error.type", "empty_animation");
+                        span->setHttpStatus(422);
+                    }
+                    return createDtoResponse(Status::CODE_422, result);
+                }
 
-        auto animationId = requestBody->animation_id ? std::string(requestBody->animation_id) : "";
-        bool resumePlaylist = requestBody->resume_playlist ? static_cast<bool>(requestBody->resume_playlist) : true;
+                const auto &track = animation.tracks.front();
+                auto creatureId = track.creature_id;
+                auto mismatchedTrack =
+                    std::any_of(animation.tracks.begin(), animation.tracks.end(),
+                                [&](const creatures::Track &candidate) { return candidate.creature_id != creatureId; });
+                if (mismatchedTrack) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 422;
+                    result->message = "Prepared animation targets multiple creatures; cannot auto-play.";
+                    if (span) {
+                        span->setAttribute("error.type", "multi_creature_animation");
+                        span->setHttpStatus(422);
+                    }
+                    return createDtoResponse(Status::CODE_422, result);
+                }
 
-        if (span) {
-            span->setAttribute("animation.id", animationId);
-            span->setAttribute("resume_playlist", resumePlaylist);
-        }
+                if (creatureId.empty()) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 500;
+                    result->message = "Prepared animation track is missing creature_id";
+                    if (span) {
+                        span->setAttribute("error.type", "missing_creature_id");
+                        span->setHttpStatus(500);
+                    }
+                    return createDtoResponse(Status::CODE_500, result);
+                }
 
-        if (animationId.empty()) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 400;
-            result->message = "animation_id is required";
-            if (span) {
-                span->setAttribute("error.type", "invalid_request");
-                span->setHttpStatus(400);
-            }
-            return createDtoResponse(Status::CODE_400, result);
-        }
+                universe_t universe;
+                try {
+                    auto universePtr = creatures::creatureUniverseMap->get(creatureId);
+                    universe = *universePtr;
+                } catch (const std::exception &) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 409;
+                    result->message =
+                        fmt::format("Creature {} is not registered with a universe. Is the controller online?",
+                                    creatureId)
+                            .c_str();
+                    if (span) {
+                        span->setAttribute("error.type", "creature_not_registered");
+                        span->setHttpStatus(409);
+                    }
+                    return createDtoResponse(Status::CODE_409, result);
+                }
 
-        auto animationLookupSpan =
-            creatures::observability
-                ? creatures::observability->createOperationSpan("AnimationController.getAdHocAnimation", span)
-                : nullptr;
-        if (animationLookupSpan) {
-            animationLookupSpan->setAttribute("animation.id", animationId);
-        }
+                auto sessionResult =
+                    creatures::sessionManager->interruptIdleOnly(universe, animation, std::string(creatureId), span);
+                if (!sessionResult.isSuccess()) {
+                    auto error = sessionResult.getError().value();
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->message = error.getMessage().c_str();
 
-        auto animationResult = creatures::db->getAdHocAnimation(animationId, animationLookupSpan);
-        if (!animationResult.isSuccess()) {
-            auto error = animationResult.getError().value();
-            auto response = creatures::ws::StatusDto::createShared();
-            response->status = "error";
-            response->message = error.getMessage().c_str();
-            Status status = Status::CODE_500;
-            switch (error.getCode()) {
-            case ServerError::NotFound:
-                status = Status::CODE_404;
-                break;
-            case ServerError::InvalidData:
-                status = Status::CODE_400;
-                break;
-            default:
-                status = Status::CODE_500;
-                break;
-            }
-            response->code = status.code;
-            if (span) {
-                span->setHttpStatus(status.code);
-                span->setAttribute("error.type", "adhoc_animation_lookup_failed");
-            }
-            if (animationLookupSpan) {
-                animationLookupSpan->setError(error.getMessage());
-            }
-            return createDtoResponse(status, response);
-        }
+                    Status status = Status::CODE_500;
+                    switch (error.getCode()) {
+                    case ServerError::Conflict:
+                        status = Status::CODE_409;
+                        break;
+                    case ServerError::InvalidData:
+                        status = Status::CODE_400;
+                        break;
+                    default:
+                        status = Status::CODE_500;
+                        break;
+                    }
 
-        auto animation = animationResult.getValue().value();
-        if (animationLookupSpan) {
-            animationLookupSpan->setSuccess();
-        }
-        if (animation.tracks.empty()) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 422;
-            result->message = "Prepared animation has no tracks";
-            if (span) {
-                span->setAttribute("error.type", "empty_animation");
-                span->setHttpStatus(422);
-            }
-            return createDtoResponse(Status::CODE_422, result);
-        }
+                    result->code = status.code;
+                    if (span) {
+                        span->setAttribute("error.type", "session_interrupt_failed");
+                        span->setHttpStatus(status.code);
+                    }
+                    return createDtoResponse(status, result);
+                }
 
-        const auto &track = animation.tracks.front();
-        auto creatureId = track.creature_id;
-        auto mismatchedTrack =
-            std::any_of(animation.tracks.begin(), animation.tracks.end(),
-                        [&](const creatures::Track &candidate) { return candidate.creature_id != creatureId; });
-        if (mismatchedTrack) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 422;
-            result->message = "Prepared animation targets multiple creatures; cannot auto-play.";
-            if (span) {
-                span->setAttribute("error.type", "multi_creature_animation");
-                span->setHttpStatus(422);
-            }
-            return createDtoResponse(Status::CODE_422, result);
-        }
+                auto response = creatures::ws::StatusDto::createShared();
+                response->status = "ok";
+                response->code = 200;
+                response->message = fmt::format("Triggered ad-hoc animation {} for {} on universe {}", animationId,
+                                                creatureId, universe)
+                                        .c_str();
+                response->session_id = sessionResult.getValue().value()->getSessionId().c_str();
 
-        if (creatureId.empty()) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 500;
-            result->message = "Prepared animation track is missing creature_id";
-            if (span) {
-                span->setAttribute("error.type", "missing_creature_id");
-                span->setHttpStatus(500);
-            }
-            return createDtoResponse(Status::CODE_500, result);
-        }
+                if (span) {
+                    span->setAttribute("creature.id", creatureId);
+                    span->setAttribute("universe", static_cast<int64_t>(universe));
+                    span->setAttribute("session.id", sessionResult.getValue().value()->getSessionId());
+                    span->setHttpStatus(200);
+                }
 
-        universe_t universe;
-        try {
-            auto universePtr = creatures::creatureUniverseMap->get(creatureId);
-            universe = *universePtr;
-        } catch (const std::exception &) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 409;
-            result->message =
-                fmt::format("Creature {} is not registered with a universe. Is the controller online?", creatureId)
-                    .c_str();
-            if (span) {
-                span->setAttribute("error.type", "creature_not_registered");
-                span->setHttpStatus(409);
-            }
-            return createDtoResponse(Status::CODE_409, result);
-        }
-
-        auto sessionResult =
-            creatures::sessionManager->interruptIdleOnly(universe, animation, std::string(creatureId), span);
-        if (!sessionResult.isSuccess()) {
-            auto error = sessionResult.getError().value();
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->message = error.getMessage().c_str();
-
-            Status status = Status::CODE_500;
-            switch (error.getCode()) {
-            case ServerError::Conflict:
-                status = Status::CODE_409;
-                break;
-            case ServerError::InvalidData:
-                status = Status::CODE_400;
-                break;
-            default:
-                status = Status::CODE_500;
-                break;
-            }
-
-            result->code = status.code;
-            if (span) {
-                span->setAttribute("error.type", "session_interrupt_failed");
-                span->setHttpStatus(status.code);
-            }
-            return createDtoResponse(status, result);
-        }
-
-        auto response = creatures::ws::StatusDto::createShared();
-        response->status = "ok";
-        response->code = 200;
-        response->message =
-            fmt::format("Triggered ad-hoc animation {} for {} on universe {}", animationId, creatureId, universe)
-                .c_str();
-        response->session_id = sessionResult.getValue().value()->getSessionId().c_str();
-
-        if (span) {
-            span->setAttribute("creature.id", creatureId);
-            span->setAttribute("universe", static_cast<int64_t>(universe));
-            span->setAttribute("session.id", sessionResult.getValue().value()->getSessionId());
-            span->setHttpStatus(200);
-        }
-
-        return createDtoResponse(Status::CODE_200, response);
+                return createDtoResponse(Status::CODE_200, response);
+            });
     }
 
   private:
@@ -851,151 +723,147 @@ class AnimationController : public oatpp::web::server::api::ApiController {
     handleAdHocAnimationRequest(const oatpp::Object<creatures::ws::CreateAdHocAnimationRequestDto> &requestBody,
                                 const std::shared_ptr<oatpp::web::protocol::http::incoming::Request> &request,
                                 creatures::jobs::JobType jobType, bool autoPlay, const std::string &spanName,
-                                const std::string &endpointPath) {
+                                const std::string &endpointPath, const std::string &endpointName) {
+        return runEndpoint(
+            spanName, "POST", endpointPath, endpointName, "AnimationController", request,
+            [&](const auto &span) -> std::shared_ptr<OutgoingResponse> {
+                if (span) {
+                    span->setAttribute("auto_play", autoPlay);
+                }
 
-        auto span = creatures::observability
-                        ? creatures::observability->createRequestSpan(spanName, "POST", endpointPath,
-                                                                      extractTraceparent(request))
-                        : nullptr;
-        addHttpRequestAttributes(span, request);
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
+                if (!creatures::config || !creatures::db || !creatures::sessionManager) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 500;
+                    result->message = "Ad-hoc request unavailable: server dependencies missing";
+                    if (span) {
+                        span->setAttribute("error.type", "missing_dependencies");
+                        span->setHttpStatus(500);
+                    }
+                    return createDtoResponse(Status::CODE_500, result);
+                }
 
-        if (span) {
-            span->setAttribute("auto_play", autoPlay);
-        }
+                if (creatures::config->getAnimationSchedulerType() !=
+                    creatures::Configuration::AnimationSchedulerType::Cooperative) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 400;
+                    result->message = "Ad-hoc speech requires the cooperative scheduler (--scheduler cooperative)";
+                    if (span) {
+                        span->setAttribute("error.type", "scheduler_not_supported");
+                        span->setHttpStatus(400);
+                    }
+                    return createDtoResponse(Status::CODE_400, result);
+                }
 
-        if (!creatures::config || !creatures::db || !creatures::sessionManager) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 500;
-            result->message = "Ad-hoc request unavailable: server dependencies missing";
-            if (span) {
-                span->setAttribute("error.type", "missing_dependencies");
-                span->setHttpStatus(500);
-            }
-            return createDtoResponse(Status::CODE_500, result);
-        }
+                auto creatureId = requestBody->creature_id ? std::string(requestBody->creature_id) : "";
+                auto text = requestBody->text ? std::string(requestBody->text) : "";
+                bool resumePlaylist =
+                    requestBody->resume_playlist ? static_cast<bool>(requestBody->resume_playlist) : true;
 
-        if (creatures::config->getAnimationSchedulerType() !=
-            creatures::Configuration::AnimationSchedulerType::Cooperative) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 400;
-            result->message = "Ad-hoc speech requires the cooperative scheduler (--scheduler cooperative)";
-            if (span) {
-                span->setAttribute("error.type", "scheduler_not_supported");
-                span->setHttpStatus(400);
-            }
-            return createDtoResponse(Status::CODE_400, result);
-        }
+                if (span) {
+                    span->setAttribute("creature.id", creatureId);
+                    span->setAttribute("text.length", static_cast<int64_t>(text.size()));
+                    span->setAttribute("resume_playlist", resumePlaylist);
+                }
 
-        auto creatureId = requestBody->creature_id ? std::string(requestBody->creature_id) : "";
-        auto text = requestBody->text ? std::string(requestBody->text) : "";
-        bool resumePlaylist = requestBody->resume_playlist ? static_cast<bool>(requestBody->resume_playlist) : true;
+                if (creatureId.empty() || text.empty()) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 400;
+                    result->message = "creature_id and text are required";
+                    if (span) {
+                        span->setAttribute("error.type", "invalid_request");
+                        span->setHttpStatus(400);
+                    }
+                    return createDtoResponse(Status::CODE_400, result);
+                }
 
-        if (span) {
-            span->setAttribute("creature.id", creatureId);
-            span->setAttribute("text.length", static_cast<int64_t>(text.size()));
-            span->setAttribute("resume_playlist", resumePlaylist);
-        }
+                auto creatureLookupSpan =
+                    creatures::observability->createOperationSpan("AnimationController.lookupCreature", span);
+                if (creatureLookupSpan) {
+                    creatureLookupSpan->setAttribute("creature.id", creatureId);
+                }
 
-        if (creatureId.empty() || text.empty()) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 400;
-            result->message = "creature_id and text are required";
-            if (span) {
-                span->setAttribute("error.type", "invalid_request");
-                span->setHttpStatus(400);
-            }
-            return createDtoResponse(Status::CODE_400, result);
-        }
+                auto creatureResult = creatures::db->getCreature(creatureId, creatureLookupSpan);
+                if (!creatureResult.isSuccess()) {
+                    auto error = creatureResult.getError().value();
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->message = error.getMessage().c_str();
+                    Status status = Status::CODE_500;
+                    switch (error.getCode()) {
+                    case ServerError::NotFound:
+                        status = Status::CODE_404;
+                        break;
+                    case ServerError::InvalidData:
+                        status = Status::CODE_400;
+                        break;
+                    default:
+                        status = Status::CODE_500;
+                        break;
+                    }
+                    result->code = status.code;
+                    if (creatureLookupSpan) {
+                        creatureLookupSpan->setError(error.getMessage());
+                        creatureLookupSpan->setAttribute("error.code", static_cast<int64_t>(status.code));
+                    }
+                    if (span) {
+                        span->setAttribute("error.type", "creature_lookup_failed");
+                        span->setHttpStatus(status.code);
+                    }
+                    return createDtoResponse(status, result);
+                }
 
-        auto creatureLookupSpan =
-            creatures::observability->createOperationSpan("AnimationController.lookupCreature", span);
-        if (creatureLookupSpan) {
-            creatureLookupSpan->setAttribute("creature.id", creatureId);
-        }
+                if (creatureLookupSpan) {
+                    creatureLookupSpan->setSuccess();
+                }
 
-        auto creatureResult = creatures::db->getCreature(creatureId, creatureLookupSpan);
-        if (!creatureResult.isSuccess()) {
-            auto error = creatureResult.getError().value();
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->message = error.getMessage().c_str();
-            Status status = Status::CODE_500;
-            switch (error.getCode()) {
-            case ServerError::NotFound:
-                status = Status::CODE_404;
-                break;
-            case ServerError::InvalidData:
-                status = Status::CODE_400;
-                break;
-            default:
-                status = Status::CODE_500;
-                break;
-            }
-            result->code = status.code;
-            if (creatureLookupSpan) {
-                creatureLookupSpan->setError(error.getMessage());
-                creatureLookupSpan->setAttribute("error.code", static_cast<int64_t>(status.code));
-            }
-            if (span) {
-                span->setAttribute("error.type", "creature_lookup_failed");
-                span->setHttpStatus(status.code);
-            }
-            return createDtoResponse(status, result);
-        }
+                const auto creature = creatureResult.getValue().value();
+                if (creature.speech_loop_animation_ids.empty()) {
+                    auto result = creatures::ws::StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 422;
+                    result->message =
+                        fmt::format("{} has no speech_loop_animation_ids configured; ad-hoc speech cannot proceed.",
+                                    creature.name)
+                            .c_str();
+                    if (span) {
+                        span->setAttribute("error.type", "missing_speech_loop_animation_ids");
+                        span->setHttpStatus(422);
+                    }
+                    return createDtoResponse(Status::CODE_422, result);
+                }
 
-        if (creatureLookupSpan) {
-            creatureLookupSpan->setSuccess();
-        }
+                nlohmann::json jobDetails;
+                jobDetails["creature_id"] = creatureId;
+                jobDetails["text"] = text;
+                jobDetails["resume_playlist"] = resumePlaylist;
+                jobDetails["auto_play"] = autoPlay;
 
-        const auto creature = creatureResult.getValue().value();
-        if (creature.speech_loop_animation_ids.empty()) {
-            auto result = creatures::ws::StatusDto::createShared();
-            result->status = "error";
-            result->code = 422;
-            result->message =
-                fmt::format("{} has no speech_loop_animation_ids configured; ad-hoc speech cannot proceed.",
-                            creature.name)
-                    .c_str();
-            if (span) {
-                span->setAttribute("error.type", "missing_speech_loop_animation_ids");
-                span->setHttpStatus(422);
-            }
-            return createDtoResponse(Status::CODE_422, result);
-        }
+                auto jobId = creatures::jobManager->createJob(jobType, jobDetails.dump(), span);
+                creatures::jobWorker->queueJob(jobId);
 
-        nlohmann::json jobDetails;
-        jobDetails["creature_id"] = creatureId;
-        jobDetails["text"] = text;
-        jobDetails["resume_playlist"] = resumePlaylist;
-        jobDetails["auto_play"] = autoPlay;
+                auto response = JobCreatedDto::createShared();
+                response->job_id = jobId;
+                response->job_type = creatures::jobs::toString(jobType).c_str();
+                if (autoPlay) {
+                    response->message = fmt::format(
+                        "Ad-hoc speech job created for '{}'. Listen for job-progress and job-complete messages.",
+                        creatureId);
+                } else {
+                    response->message = fmt::format(
+                        "Prepared ad-hoc speech job created for '{}'. Call /api/v1/animation/ad-hoc/play when ready.",
+                        creatureId);
+                }
 
-        auto jobId = creatures::jobManager->createJob(jobType, jobDetails.dump(), span);
-        creatures::jobWorker->queueJob(jobId);
+                if (span) {
+                    span->setHttpStatus(202);
+                    span->setAttribute("job.id", jobId);
+                }
 
-        auto response = JobCreatedDto::createShared();
-        response->job_id = jobId;
-        response->job_type = creatures::jobs::toString(jobType).c_str();
-        if (autoPlay) {
-            response->message = fmt::format(
-                "Ad-hoc speech job created for '{}'. Listen for job-progress and job-complete messages.", creatureId);
-        } else {
-            response->message = fmt::format(
-                "Prepared ad-hoc speech job created for '{}'. Call /api/v1/animation/ad-hoc/play when ready.",
-                creatureId);
-        }
-
-        if (span) {
-            span->setHttpStatus(202);
-            span->setAttribute("job.id", jobId);
-        }
-
-        return createDtoResponse(Status::CODE_202, response);
+                return createDtoResponse(Status::CODE_202, response);
+            });
     }
 };
 } // namespace creatures::ws

--- a/src/server/ws/controller/CreatureController.h
+++ b/src/server/ws/controller/CreatureController.h
@@ -15,15 +15,10 @@ using json = nlohmann::json;
 #include "server/database.h"
 
 #include "server/metrics/counters.h"
+#include "server/ws/controller/ControllerUtils.h"
 #include "server/ws/dto/IdleToggleDto.h"
 #include "server/ws/dto/RegisterCreatureRequestDto.h"
-#include "server/ws/controller/ControllerUtils.h"
 #include "server/ws/service/CreatureService.h"
-
-namespace creatures {
-extern std::shared_ptr<SystemCounters> metrics;
-extern std::shared_ptr<ObservabilityManager> observability;
-} // namespace creatures
 
 #include OATPP_CODEGEN_BEGIN(ApiController)
 
@@ -50,35 +45,14 @@ class CreatureController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<CreaturesListDto>>(Status::CODE_200, "application/json; charset=utf-8");
         info->addResponse<Object<StatusDto>>(Status::CODE_500, "application/json; charset=utf-8");
     }
-    ENDPOINT("GET", "api/v1/creature", getAllCreatures,
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        // Create a trace span for this request
-        const auto span =
-            creatures::observability
-                ? creatures::observability->createRequestSpan("GET /api/v1/creature", "GET", "api/v1/creature",
-                                                              extractTraceparent(request))
-                : nullptr;
-        addHttpRequestAttributes(span, request);
-
-        if (creatures::metrics) {
-            if (creatures::metrics) {
-                creatures::metrics->incrementRestRequestsProcessed();
-            }
-        }
-
-        if (span) {
-            span->setAttribute("endpoint.name", "getAllCreatures");
-            span->setAttribute("controller.name", "CreatureController");
-        }
-
-        const auto result = m_creatureService.getAllCreatures(span);
-
-        // Record success metrics in the span
-        if (span) {
-            span->setHttpStatus(200);
-        }
-
-        return createDtoResponse(Status::CODE_200, result);
+    ENDPOINT("GET", "api/v1/creature", getAllCreatures, REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint("GET /api/v1/creature", "GET", "api/v1/creature", "getAllCreatures", "CreatureController",
+                           request, [&](const auto &span) {
+                               const auto result = m_creatureService.getAllCreatures(span);
+                               if (span)
+                                   span->setHttpStatus(200);
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(getCreature) {
@@ -92,33 +66,18 @@ class CreatureController : public oatpp::web::server::api::ApiController {
         info->pathParams["creatureId"].description = "Creature ID in the form of an UUID";
     }
     ENDPOINT("GET", "api/v1/creature/{creatureId}", getCreature, PATH(String, creatureId),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        // RequestSpan only handles HTTP-level concerns
-        const auto span =
-            creatures::observability
-                ? creatures::observability->createRequestSpan("GET /api/v1/creature/{creatureId}", "GET",
-                                                              "api/v1/creature/" + std::string(creatureId),
-                                                              extractTraceparent(request))
-                : nullptr;
-        addHttpRequestAttributes(span, request);
-
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
-
-        if (span) {
-            span->setAttribute("endpoint.name", "getCreature");
-            span->setAttribute("controller.name", "CreatureController");
-            span->setAttribute("creature.id", std::string(creatureId));
-        }
-
-        const auto result = m_creatureService.getCreature(creatureId, span);
-
-        if (span) {
-            span->setHttpStatus(200);
-        }
-
-        return createDtoResponse(Status::CODE_200, result);
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        OATPP_ASSERT_HTTP(creatureId && isUuidShape(std::string(creatureId)), Status::CODE_400,
+                          "creatureId must be a UUID");
+        return runEndpoint("GET /api/v1/creature/{creatureId}", "GET", "api/v1/creature/" + std::string(creatureId),
+                           "getCreature", "CreatureController", request, [&](const auto &span) {
+                               if (span)
+                                   span->setAttribute("creature.id", std::string(creatureId));
+                               const auto result = m_creatureService.getCreature(creatureId, span);
+                               if (span)
+                                   span->setHttpStatus(200);
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(upsertCreature) {
@@ -133,50 +92,25 @@ class CreatureController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<StatusDto>>(Status::CODE_500, "application/json; charset=utf-8");
     }
     ENDPOINT("POST", "api/v1/creature", upsertCreature, BODY_STRING(String, body),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        const auto span =
-            creatures::observability
-                ? creatures::observability->createRequestSpan("POST /api/v1/creature", "POST", "api/v1/creature",
-                                                              extractTraceparent(request))
-                : nullptr;
-        addHttpRequestAttributes(span, request);
-
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
         debug("Upserting creature via POST /api/v1/creature");
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
-
-        try {
-            const auto creatureConfig = std::string(body);
-
-            if (span) {
-                span->setAttribute("endpoint.name", "upsertCreature");
-                span->setAttribute("controller.name", "CreatureController");
-                span->setAttribute("request.body_size", static_cast<int64_t>(creatureConfig.length()));
-            }
-
-            const auto result = m_creatureService.upsertCreature(creatureConfig, span);
-
-            if (span) {
-                span->setAttribute("creature.id", std::string(result->id));
-                span->setAttribute("creature.name", std::string(result->name));
-                span->setHttpStatus(200);
-            }
-
-            // Schedule an event to invalidate the creature cache on the clients
-            scheduleCacheInvalidationEvent(CACHE_INVALIDATION_DELAY_TIME, CacheType::Creature);
-
-            return createDtoResponse(Status::CODE_200, result);
-
-        } catch (const std::exception &ex) {
-            if (span) {
-                span->recordException(ex);
-                span->setHttpStatus(500);
-            }
-
-            error("Exception in upsertCreature: {}", ex.what());
-            throw;
-        }
+        return runEndpoint("POST /api/v1/creature", "POST", "api/v1/creature", "upsertCreature", "CreatureController",
+                           request, [&](const auto &span) {
+                               const auto creatureConfig = std::string(body);
+                               if (span) {
+                                   span->setAttribute("request.body_size",
+                                                      static_cast<int64_t>(creatureConfig.length()));
+                               }
+                               const auto result = m_creatureService.upsertCreature(creatureConfig, span);
+                               if (span) {
+                                   span->setAttribute("creature.id", std::string(result->id));
+                                   span->setAttribute("creature.name", std::string(result->name));
+                                   span->setHttpStatus(200);
+                               }
+                               // Schedule an event to invalidate the creature cache on the clients
+                               scheduleCacheInvalidationEvent(CACHE_INVALIDATION_DELAY_TIME, CacheType::Creature);
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(validateCreatureConfig) {
@@ -186,30 +120,18 @@ class CreatureController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<StatusDto>>(Status::CODE_400, "application/json; charset=utf-8");
     }
     ENDPOINT("POST", "api/v1/creature/validate", validateCreatureConfig, BODY_STRING(String, body),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        auto span = creatures::observability ? creatures::observability->createRequestSpan(
-                                                   "POST /api/v1/creature/validate", "POST", "api/v1/creature/validate",
-                                                   extractTraceparent(request))
-                                             : nullptr;
-        addHttpRequestAttributes(span, request);
-
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
-
-        if (span) {
-            span->setAttribute("endpoint.name", "validateCreatureConfig");
-            span->setAttribute("controller.name", "CreatureController");
-            span->setAttribute("request.body_size", static_cast<int64_t>(body ? body->size() : 0));
-        }
-
-        const auto result = m_creatureService.validateCreatureConfig(std::string(body), span);
-
-        if (span) {
-            span->setHttpStatus(200);
-        }
-
-        return createDtoResponse(Status::CODE_200, result);
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint("POST /api/v1/creature/validate", "POST", "api/v1/creature/validate",
+                           "validateCreatureConfig", "CreatureController", request, [&](const auto &span) {
+                               if (span) {
+                                   span->setAttribute("request.body_size",
+                                                      static_cast<int64_t>(body ? body->size() : 0));
+                               }
+                               const auto result = m_creatureService.validateCreatureConfig(std::string(body), span);
+                               if (span)
+                                   span->setHttpStatus(200);
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(setIdleEnabled) {
@@ -220,39 +142,23 @@ class CreatureController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<StatusDto>>(Status::CODE_404, "application/json; charset=utf-8");
     }
     ENDPOINT("PATCH", "api/v1/creature/{creatureId}/idle", setIdleEnabled, PATH(String, creatureId),
-             BODY_DTO(Object<IdleToggleDto>, body),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        const auto span =
-            creatures::observability
-                ? creatures::observability->createRequestSpan("PATCH /api/v1/creature/{creatureId}/idle", "PATCH",
-                                                              "api/v1/creature/" + std::string(creatureId) + "/idle",
-                                                              extractTraceparent(request))
-                : nullptr;
-
-        addHttpRequestAttributes(span, request);
-
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
-
-        if (span) {
-            span->setAttribute("endpoint.name", "setIdleEnabled");
-            span->setAttribute("controller.name", "CreatureController");
-            span->setAttribute("creature.id", std::string(creatureId));
-        }
-
-        bool enabled = true;
-        if (body && body->enabled != nullptr) {
-            enabled = *body->enabled;
-        }
-
-        const auto result = m_creatureService.setIdleEnabled(creatureId, enabled, span);
-
-        if (span) {
-            span->setHttpStatus(200);
-        }
-
-        return createDtoResponse(Status::CODE_200, result);
+             BODY_DTO(Object<IdleToggleDto>, body), REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        OATPP_ASSERT_HTTP(creatureId && isUuidShape(std::string(creatureId)), Status::CODE_400,
+                          "creatureId must be a UUID");
+        return runEndpoint("PATCH /api/v1/creature/{creatureId}/idle", "PATCH",
+                           "api/v1/creature/" + std::string(creatureId) + "/idle", "setIdleEnabled",
+                           "CreatureController", request, [&](const auto &span) {
+                               if (span)
+                                   span->setAttribute("creature.id", std::string(creatureId));
+                               bool enabled = true;
+                               if (body && body->enabled != nullptr) {
+                                   enabled = *body->enabled;
+                               }
+                               const auto result = m_creatureService.setIdleEnabled(creatureId, enabled, span);
+                               if (span)
+                                   span->setHttpStatus(200);
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(registerCreature) {
@@ -267,85 +173,61 @@ class CreatureController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<StatusDto>>(Status::CODE_400, "application/json; charset=utf-8");
         info->addResponse<Object<StatusDto>>(Status::CODE_500, "application/json; charset=utf-8");
     }
-    ENDPOINT("POST", "api/v1/creature/register", registerCreature,
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-        const auto span = creatures::observability
-                              ? creatures::observability->createRequestSpan("POST /api/v1/creature/register", "POST",
-                                                                            "api/v1/creature/register",
-                                                                            extractTraceparent(request))
-                              : nullptr;
-
-        addHttpRequestAttributes(span, request);
-
+    ENDPOINT("POST", "api/v1/creature/register", registerCreature, REQUEST(std::shared_ptr<IncomingRequest>, request)) {
         debug("----> Controller registering creature with universe assignment");
+        return runEndpoint(
+            "POST /api/v1/creature/register", "POST", "api/v1/creature/register", "registerCreature",
+            "CreatureController", request, [&](const auto &span) {
+                // Read body manually instead of using BODY_STRING macro
+                const oatpp::String body = request->readBodyToString();
 
-        // Read body manually instead of using BODY_STRING macro
-        const oatpp::String body = request->readBodyToString();
+                debug("Raw request body size: {} bytes", body ? body->size() : 0);
+                if (body && body->size() > 0) {
+                    debug("First 200 chars of body: {}",
+                          std::string(body->data(), std::min(200UL, static_cast<size_t>(body->size()))));
+                }
 
-        // Debug: Log the raw request body
-        debug("Raw request body size: {} bytes", body ? body->size() : 0);
-        if (body && body->size() > 0) {
-            debug("First 200 chars of body: {}",
-                  std::string(body->data(), std::min(200UL, static_cast<size_t>(body->size()))));
-        }
+                // Parse the JSON manually for now
+                Object<RegisterCreatureRequestDto> dto;
+                try {
+                    const auto json = nlohmann::json::parse(std::string(body));
+                    dto = RegisterCreatureRequestDto::createShared();
+                    dto->creature_config = json.value("creature_config", "");
+                    dto->universe = json.value("universe", 0);
+                } catch (const std::exception &e) {
+                    const std::string errorMessage = fmt::format("Failed to parse request body: {}", e.what());
+                    error(errorMessage);
+                    if (span) {
+                        span->setAttribute("error.message", errorMessage);
+                        span->setHttpStatus(400);
+                    }
+                    const auto errorDto = StatusDto::createShared();
+                    errorDto->status = "ERROR";
+                    errorDto->code = 400;
+                    errorDto->message = errorMessage.c_str();
+                    return createDtoResponse(Status::CODE_400, errorDto);
+                }
 
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
+                const std::string creatureConfig = std::string(dto->creature_config);
 
-        // Parse the JSON manually for now
-        Object<RegisterCreatureRequestDto> dto;
-        try {
-            const auto json = nlohmann::json::parse(std::string(body));
-            dto = RegisterCreatureRequestDto::createShared();
-            dto->creature_config = json.value("creature_config", "");
-            dto->universe = json.value("universe", 0);
-        } catch (const std::exception &e) {
-            const std::string errorMessage = fmt::format("Failed to parse request body: {}", e.what());
-            error(errorMessage);
-            if (span) {
-                span->setAttribute("error.message", errorMessage);
-                span->setHttpStatus(400);
-            }
-            const auto errorDto = StatusDto::createShared();
-            errorDto->status = "ERROR";
-            errorDto->code = 400;
-            errorDto->message = errorMessage.c_str();
-            return createDtoResponse(Status::CODE_400, errorDto);
-        }
+                if (span) {
+                    span->setAttribute("universe", static_cast<int64_t>(dto->universe));
+                    span->setAttribute("request.body_size", static_cast<int64_t>(creatureConfig.length()));
+                }
 
-        try {
-            const std::string creatureConfig = std::string(dto->creature_config);
+                const auto result = m_creatureService.registerCreature(creatureConfig, dto->universe, span);
 
-            if (span) {
-                span->setAttribute("endpoint.name", "registerCreature");
-                span->setAttribute("controller.name", "CreatureController");
-                span->setAttribute("universe", static_cast<int64_t>(dto->universe));
-                span->setAttribute("request.body_size", static_cast<int64_t>(creatureConfig.length()));
-            }
+                if (span) {
+                    span->setAttribute("creature.id", std::string(result->id));
+                    span->setAttribute("creature.name", std::string(result->name));
+                    span->setHttpStatus(200);
+                }
 
-            const auto result = m_creatureService.registerCreature(creatureConfig, dto->universe, span);
+                // Schedule an event to invalidate the creature cache on the clients
+                scheduleCacheInvalidationEvent(CACHE_INVALIDATION_DELAY_TIME, CacheType::Creature);
 
-            if (span) {
-                span->setAttribute("creature.id", std::string(result->id));
-                span->setAttribute("creature.name", std::string(result->name));
-                span->setHttpStatus(200);
-            }
-
-            // Schedule an event to invalidate the creature cache on the clients
-            scheduleCacheInvalidationEvent(CACHE_INVALIDATION_DELAY_TIME, CacheType::Creature);
-
-            return createDtoResponse(Status::CODE_200, result);
-
-        } catch (const std::exception &ex) {
-            if (span) {
-                span->recordException(ex);
-                span->setHttpStatus(500);
-            }
-
-            error("Exception in registerCreature: {}", ex.what());
-            throw;
-        }
+                return createDtoResponse(Status::CODE_200, result);
+            });
     }
 };
 

--- a/src/server/ws/controller/SoundController.h
+++ b/src/server/ws/controller/SoundController.h
@@ -70,13 +70,14 @@ class SoundController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<StatusDto>>(Status::CODE_404, "application/json; charset=utf-8");
         info->addResponse<Object<StatusDto>>(Status::CODE_500, "application/json; charset=utf-8");
     }
-    ENDPOINT("GET", "api/v1/sound", getAllSounds) {
-        if (creatures::metrics) {
-            if (creatures::metrics) {
-                creatures::metrics->incrementRestRequestsProcessed();
-            }
-        }
-        return createDtoResponse(Status::CODE_200, m_soundService.getAllSounds());
+    ENDPOINT("GET", "api/v1/sound", getAllSounds, REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint("GET /api/v1/sound", "GET", "api/v1/sound", "getAllSounds", "SoundController", request,
+                           [&](const auto &span) {
+                               const auto result = m_soundService.getAllSounds();
+                               if (span)
+                                   span->setHttpStatus(200);
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(getAdHocSounds) {
@@ -85,11 +86,14 @@ class SoundController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<AdHocSoundListDto>>(Status::CODE_200, "application/json; charset=utf-8");
         info->addResponse<Object<StatusDto>>(Status::CODE_500, "application/json; charset=utf-8");
     }
-    ENDPOINT("GET", "api/v1/sound/ad-hoc", getAdHocSounds) {
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
-        return createDtoResponse(Status::CODE_200, m_soundService.getAdHocSounds());
+    ENDPOINT("GET", "api/v1/sound/ad-hoc", getAdHocSounds, REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint("GET /api/v1/sound/ad-hoc", "GET", "api/v1/sound/ad-hoc", "getAdHocSounds",
+                           "SoundController", request, [&](const auto &span) {
+                               const auto result = m_soundService.getAdHocSounds();
+                               if (span)
+                                   span->setHttpStatus(200);
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(playSound) {
@@ -100,12 +104,18 @@ class SoundController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<StatusDto>>(Status::CODE_404, "application/json; charset=utf-8");
         info->addResponse<Object<StatusDto>>(Status::CODE_500, "application/json; charset=utf-8");
     }
-    ENDPOINT("POST", "api/v1/sound/play", playSound,
-             BODY_DTO(Object<creatures::ws::PlaySoundRequestDTO>, requestBody)) {
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
-        return createDtoResponse(Status::CODE_200, m_soundService.playSound(std::string(requestBody->file_name)));
+    ENDPOINT("POST", "api/v1/sound/play", playSound, BODY_DTO(Object<creatures::ws::PlaySoundRequestDTO>, requestBody),
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint("POST /api/v1/sound/play", "POST", "api/v1/sound/play", "playSound", "SoundController",
+                           request, [&](const auto &span) {
+                               if (span && requestBody && requestBody->file_name) {
+                                   span->setAttribute("sound.file", std::string(requestBody->file_name));
+                               }
+                               const auto result = m_soundService.playSound(std::string(requestBody->file_name));
+                               if (span)
+                                   span->setHttpStatus(200);
+                               return createDtoResponse(Status::CODE_200, result);
+                           });
     }
 
     ENDPOINT_INFO(generateLipSyncFromUpload) {
@@ -119,250 +129,233 @@ class SoundController : public oatpp::web::server::api::ApiController {
     }
     ENDPOINT("POST", "api/v1/sound/generate-lipsync/upload", generateLipSyncFromUpload, BODY_STRING(String, body),
              QUERY(String, filename, "filename"), REQUEST(std::shared_ptr<IncomingRequest>, request)) {
-
-        auto span = creatures::observability
-                        ? creatures::observability->createRequestSpan("POST /api/v1/sound/generate-lipsync/upload",
-                                                                      "POST", "api/v1/sound/generate-lipsync/upload",
-                                                                      extractTraceparent(request))
-                        : nullptr;
-
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
         info("REST call to generateLipSyncFromUpload");
-
-        if (span) {
-            span->setAttribute("endpoint.name", "generateLipSyncFromUpload");
-            span->setAttribute("controller.name", "SoundController");
-            span->setAttribute("http.method", "POST");
-            span->setAttribute("http.target", "api/v1/sound/generate-lipsync/upload");
-        }
-
-        if (auto userAgent = request->getHeader("User-Agent"); span && userAgent) {
-            span->setAttribute("http.user_agent", std::string(userAgent));
-        }
-
-        if (!filename) {
-            auto response = StatusDto::createShared();
-            response->status = "Bad Request";
-            response->message = "Query parameter 'filename' is required.";
-            response->code = 400;
-            if (span) {
-                span->setHttpStatus(400);
-                span->setAttribute("error.message", response->message);
-            }
-            return createDtoResponse(Status::CODE_400, response);
-        }
-
-        if (!body) {
-            auto response = StatusDto::createShared();
-            response->status = "Bad Request";
-            response->message = "Request body must contain WAV data.";
-            response->code = 400;
-            if (span) {
-                span->setHttpStatus(400);
-                span->setAttribute("error.message", response->message);
-            }
-            return createDtoResponse(Status::CODE_400, response);
-        }
-
-        std::string wavData = body;
-        if (wavData.empty()) {
-            auto response = StatusDto::createShared();
-            response->status = "Bad Request";
-            response->message = "Uploaded WAV data is empty.";
-            response->code = 400;
-            if (span) {
-                span->setHttpStatus(400);
-                span->setAttribute("error.message", response->message);
-            }
-            return createDtoResponse(Status::CODE_400, response);
-        }
-
-        std::string originalFilename = filename;
-        std::string sanitizedFilename;
-        try {
-            sanitizedFilename = sanitizeFilename(originalFilename);
-        } catch (const std::invalid_argument &ex) {
-            auto response = StatusDto::createShared();
-            response->status = "Bad Request";
-            response->message = ex.what();
-            response->code = 400;
-            if (span) {
-                span->setHttpStatus(400);
-                span->setAttribute("error.message", response->message);
-            }
-            return createDtoResponse(Status::CODE_400, response);
-        }
-
-        if (!sanitizedFilename.ends_with(".wav")) {
-            auto response = StatusDto::createShared();
-            response->status = "Unprocessable Entity";
-            response->message = "Only .wav files are supported for lip sync generation.";
-            response->code = 422;
-            if (span) {
-                span->setHttpStatus(422);
-                span->setAttribute("error.message", response->message);
-            }
-            return createDtoResponse(Status::CODE_422, response);
-        }
-
-        if (span) {
-            span->setAttribute("upload.original_filename", originalFilename);
-            span->setAttribute("upload.sanitized_filename", sanitizedFilename);
-        }
-
-        auto tempRoot = fs::temp_directory_path() / "creature-server" / "lipsync-uploads";
-        auto tempDir = tempRoot / creatures::util::generateUUID();
-
-        std::error_code ec;
-        fs::create_directories(tempDir, ec);
-        if (ec) {
-            auto response = StatusDto::createShared();
-            response->status = "Internal Server Error";
-            response->message = fmt::format("Failed to create temporary directory: {}", ec.message());
-            response->code = 500;
-            if (span) {
-                span->setHttpStatus(500);
-                span->setAttribute("error.message", response->message);
-            }
-            return createDtoResponse(Status::CODE_500, response);
-        }
-
-        struct TempDirCleaner {
-            fs::path path;
-            ~TempDirCleaner() {
-                if (path.empty()) {
-                    return;
+        return runEndpoint(
+            "POST /api/v1/sound/generate-lipsync/upload", "POST", "api/v1/sound/generate-lipsync/upload",
+            "generateLipSyncFromUpload", "SoundController", request, [&](const auto &span) {
+                if (!filename) {
+                    auto response = StatusDto::createShared();
+                    response->status = "Bad Request";
+                    response->message = "Query parameter 'filename' is required.";
+                    response->code = 400;
+                    if (span) {
+                        span->setHttpStatus(400);
+                        span->setAttribute("error.message", response->message);
+                    }
+                    return createDtoResponse(Status::CODE_400, response);
                 }
-                std::error_code cleanupEc;
-                fs::remove_all(path, cleanupEc);
-                if (cleanupEc) {
-                    warn("Failed to clean up temporary lip sync directory {}: {}", path.string(), cleanupEc.message());
+
+                if (!body) {
+                    auto response = StatusDto::createShared();
+                    response->status = "Bad Request";
+                    response->message = "Request body must contain WAV data.";
+                    response->code = 400;
+                    if (span) {
+                        span->setHttpStatus(400);
+                        span->setAttribute("error.message", response->message);
+                    }
+                    return createDtoResponse(Status::CODE_400, response);
                 }
-            }
-        } cleanupGuard{tempDir};
 
-        auto wavPath = tempDir / sanitizedFilename;
-        std::ofstream wavFile(wavPath, std::ios::binary);
-        if (!wavFile.is_open()) {
-            auto response = StatusDto::createShared();
-            response->status = "Internal Server Error";
-            response->message = "Failed to write uploaded WAV file.";
-            response->code = 500;
-            if (span) {
-                span->setHttpStatus(500);
-                span->setAttribute("error.message", response->message);
-            }
-            return createDtoResponse(Status::CODE_500, response);
-        }
+                std::string wavData = body;
+                if (wavData.empty()) {
+                    auto response = StatusDto::createShared();
+                    response->status = "Bad Request";
+                    response->message = "Uploaded WAV data is empty.";
+                    response->code = 400;
+                    if (span) {
+                        span->setHttpStatus(400);
+                        span->setAttribute("error.message", response->message);
+                    }
+                    return createDtoResponse(Status::CODE_400, response);
+                }
 
-        wavFile.write(wavData.data(), static_cast<std::streamsize>(wavData.size()));
-        if (!wavFile.good()) {
-            auto response = StatusDto::createShared();
-            response->status = "Internal Server Error";
-            response->message = "Failed to persist uploaded WAV data.";
-            response->code = 500;
-            if (span) {
-                span->setHttpStatus(500);
-                span->setAttribute("error.message", response->message);
-            }
-            return createDtoResponse(Status::CODE_500, response);
-        }
-        wavFile.close();
+                std::string originalFilename = filename;
+                std::string sanitizedFilename;
+                try {
+                    sanitizedFilename = sanitizeFilename(originalFilename);
+                } catch (const std::invalid_argument &ex) {
+                    auto response = StatusDto::createShared();
+                    response->status = "Bad Request";
+                    response->message = ex.what();
+                    response->code = 400;
+                    if (span) {
+                        span->setHttpStatus(400);
+                        span->setAttribute("error.message", response->message);
+                    }
+                    return createDtoResponse(Status::CODE_400, response);
+                }
 
-        if (span) {
-            span->setAttribute("upload.filename", sanitizedFilename);
-            span->setAttribute("upload.size_bytes", static_cast<int64_t>(wavData.size()));
-            span->setAttribute("upload.temp_path", wavPath.string());
-        }
+                if (!sanitizedFilename.ends_with(".wav")) {
+                    auto response = StatusDto::createShared();
+                    response->status = "Unprocessable Entity";
+                    response->message = "Only .wav files are supported for lip sync generation.";
+                    response->code = 422;
+                    if (span) {
+                        span->setHttpStatus(422);
+                        span->setAttribute("error.message", response->message);
+                    }
+                    return createDtoResponse(Status::CODE_422, response);
+                }
 
-        std::string rhubarbBinaryPath = creatures::config->getRhubarbBinaryPath();
-        if (span) {
-            span->setAttribute("rhubarb.binary", rhubarbBinaryPath);
-        }
+                if (span) {
+                    span->setAttribute("upload.original_filename", originalFilename);
+                    span->setAttribute("upload.sanitized_filename", sanitizedFilename);
+                }
 
-        auto result = voice::LipSyncProcessor::generateLipSync(sanitizedFilename, tempDir.string(), rhubarbBinaryPath,
-                                                               true, nullptr, nullptr);
+                auto tempRoot = fs::temp_directory_path() / "creature-server" / "lipsync-uploads";
+                auto tempDir = tempRoot / creatures::util::generateUUID();
 
-        if (!result.isSuccess()) {
-            auto errorResult = result.getError().value();
-            auto response = StatusDto::createShared();
-            response->status = "Lip Sync Generation Failed";
-            response->message = errorResult.getMessage();
-            int statusCode = serverErrorToStatusCode(errorResult.getCode());
-            response->code = statusCode;
-            auto status = Status::CODE_500;
-            switch (statusCode) {
-            case 400:
-                status = Status::CODE_400;
-                break;
-            case 403:
-                status = Status::CODE_403;
-                break;
-            case 404:
-                status = Status::CODE_404;
-                break;
-            default:
-                status = Status::CODE_500;
-                break;
-            }
+                std::error_code ec;
+                fs::create_directories(tempDir, ec);
+                if (ec) {
+                    auto response = StatusDto::createShared();
+                    response->status = "Internal Server Error";
+                    response->message = fmt::format("Failed to create temporary directory: {}", ec.message());
+                    response->code = 500;
+                    if (span) {
+                        span->setHttpStatus(500);
+                        span->setAttribute("error.message", response->message);
+                    }
+                    return createDtoResponse(Status::CODE_500, response);
+                }
 
-            if (span) {
-                span->setHttpStatus(status.code);
-                span->setAttribute("error.message", errorResult.getMessage());
-            }
+                struct TempDirCleaner {
+                    fs::path path;
+                    ~TempDirCleaner() {
+                        if (path.empty()) {
+                            return;
+                        }
+                        std::error_code cleanupEc;
+                        fs::remove_all(path, cleanupEc);
+                        if (cleanupEc) {
+                            warn("Failed to clean up temporary lip sync directory {}: {}", path.string(),
+                                 cleanupEc.message());
+                        }
+                    }
+                } cleanupGuard{tempDir};
 
-            return createDtoResponse(status, response);
-        }
+                auto wavPath = tempDir / sanitizedFilename;
+                std::ofstream wavFile(wavPath, std::ios::binary);
+                if (!wavFile.is_open()) {
+                    auto response = StatusDto::createShared();
+                    response->status = "Internal Server Error";
+                    response->message = "Failed to write uploaded WAV file.";
+                    response->code = 500;
+                    if (span) {
+                        span->setHttpStatus(500);
+                        span->setAttribute("error.message", response->message);
+                    }
+                    return createDtoResponse(Status::CODE_500, response);
+                }
 
-        auto jsonContent = result.getValue().value();
+                wavFile.write(wavData.data(), static_cast<std::streamsize>(wavData.size()));
+                if (!wavFile.good()) {
+                    auto response = StatusDto::createShared();
+                    response->status = "Internal Server Error";
+                    response->message = "Failed to persist uploaded WAV data.";
+                    response->code = 500;
+                    if (span) {
+                        span->setHttpStatus(500);
+                        span->setAttribute("error.message", response->message);
+                    }
+                    return createDtoResponse(Status::CODE_500, response);
+                }
+                wavFile.close();
 
-        RhubarbSoundData lipSyncData;
-        try {
-            lipSyncData = creatures::RhubarbSoundData::fromJsonString(jsonContent);
-        } catch (const std::exception &e) {
-            auto response = StatusDto::createShared();
-            response->status = "Internal Server Error";
-            response->message = fmt::format("Failed to parse Rhubarb JSON output: {}", e.what());
-            response->code = 500;
-            if (span) {
-                span->setHttpStatus(500);
-                span->setAttribute("error.message", response->message);
-            }
-            return createDtoResponse(Status::CODE_500, response);
-        }
+                if (span) {
+                    span->setAttribute("upload.filename", sanitizedFilename);
+                    span->setAttribute("upload.size_bytes", static_cast<int64_t>(wavData.size()));
+                    span->setAttribute("upload.temp_path", wavPath.string());
+                }
 
-        auto metadataDto = creatures::ws::RhubarbMetadataDto::createShared();
-        metadataDto->soundFile = lipSyncData.metadata.soundFile;
-        metadataDto->duration = lipSyncData.metadata.duration;
+                std::string rhubarbBinaryPath = creatures::config->getRhubarbBinaryPath();
+                if (span) {
+                    span->setAttribute("rhubarb.binary", rhubarbBinaryPath);
+                }
 
-        auto mouthCuesDto = oatpp::List<oatpp::Object<creatures::ws::RhubarbMouthCueDto>>::createShared();
-        for (const auto &cue : lipSyncData.mouthCues) {
-            auto cueDto = creatures::ws::RhubarbMouthCueDto::createShared();
-            cueDto->start = cue.start;
-            cueDto->end = cue.end;
-            cueDto->value = cue.value;
-            mouthCuesDto->push_back(cueDto);
-        }
+                auto result = voice::LipSyncProcessor::generateLipSync(sanitizedFilename, tempDir.string(),
+                                                                       rhubarbBinaryPath, true, nullptr, nullptr);
 
-        auto responseDto = GenerateLipSyncUploadResponseDto::createShared();
-        responseDto->metadata = metadataDto;
-        responseDto->mouthCues = mouthCuesDto;
+                if (!result.isSuccess()) {
+                    auto errorResult = result.getError().value();
+                    auto response = StatusDto::createShared();
+                    response->status = "Lip Sync Generation Failed";
+                    response->message = errorResult.getMessage();
+                    int statusCode = serverErrorToStatusCode(errorResult.getCode());
+                    response->code = statusCode;
+                    auto status = Status::CODE_500;
+                    switch (statusCode) {
+                    case 400:
+                        status = Status::CODE_400;
+                        break;
+                    case 403:
+                        status = Status::CODE_403;
+                        break;
+                    case 404:
+                        status = Status::CODE_404;
+                        break;
+                    default:
+                        status = Status::CODE_500;
+                        break;
+                    }
 
-        auto jsonFilename = fmt::format("{}.json", sanitizedFilename.substr(0, sanitizedFilename.size() - 4));
+                    if (span) {
+                        span->setHttpStatus(status.code);
+                        span->setAttribute("error.message", errorResult.getMessage());
+                    }
 
-        if (span) {
-            span->setHttpStatus(200);
-            span->setAttribute("json.size_bytes", static_cast<int64_t>(jsonContent.size()));
-            span->setAttribute("json.filename", jsonFilename);
-            span->setAttribute("json.mouth_cues", static_cast<int64_t>(lipSyncData.mouthCues.size()));
-        }
+                    return createDtoResponse(status, response);
+                }
 
-        auto response = createDtoResponse(Status::CODE_200, responseDto);
-        response->putHeader("Content-Type", "application/json; charset=utf-8");
-        response->putHeader("Content-Disposition", fmt::format("attachment; filename=\"{}\"", jsonFilename));
-        return response;
+                auto jsonContent = result.getValue().value();
+
+                RhubarbSoundData lipSyncData;
+                try {
+                    lipSyncData = creatures::RhubarbSoundData::fromJsonString(jsonContent);
+                } catch (const std::exception &e) {
+                    auto response = StatusDto::createShared();
+                    response->status = "Internal Server Error";
+                    response->message = fmt::format("Failed to parse Rhubarb JSON output: {}", e.what());
+                    response->code = 500;
+                    if (span) {
+                        span->setHttpStatus(500);
+                        span->setAttribute("error.message", response->message);
+                    }
+                    return createDtoResponse(Status::CODE_500, response);
+                }
+
+                auto metadataDto = creatures::ws::RhubarbMetadataDto::createShared();
+                metadataDto->soundFile = lipSyncData.metadata.soundFile;
+                metadataDto->duration = lipSyncData.metadata.duration;
+
+                auto mouthCuesDto = oatpp::List<oatpp::Object<creatures::ws::RhubarbMouthCueDto>>::createShared();
+                for (const auto &cue : lipSyncData.mouthCues) {
+                    auto cueDto = creatures::ws::RhubarbMouthCueDto::createShared();
+                    cueDto->start = cue.start;
+                    cueDto->end = cue.end;
+                    cueDto->value = cue.value;
+                    mouthCuesDto->push_back(cueDto);
+                }
+
+                auto responseDto = GenerateLipSyncUploadResponseDto::createShared();
+                responseDto->metadata = metadataDto;
+                responseDto->mouthCues = mouthCuesDto;
+
+                auto jsonFilename = fmt::format("{}.json", sanitizedFilename.substr(0, sanitizedFilename.size() - 4));
+
+                if (span) {
+                    span->setHttpStatus(200);
+                    span->setAttribute("json.size_bytes", static_cast<int64_t>(jsonContent.size()));
+                    span->setAttribute("json.filename", jsonFilename);
+                    span->setAttribute("json.mouth_cues", static_cast<int64_t>(lipSyncData.mouthCues.size()));
+                }
+
+                auto response = createDtoResponse(Status::CODE_200, responseDto);
+                response->putHeader("Content-Type", "application/json; charset=utf-8");
+                response->putHeader("Content-Disposition", fmt::format("attachment; filename=\"{}\"", jsonFilename));
+                return response;
+            });
     }
 
     static std::string sanitizeFilename(const std::string &filename) {
@@ -407,102 +400,96 @@ class SoundController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<StatusDto>>(Status::CODE_404, "application/json; charset=utf-8");
         info->addResponse<Object<StatusDto>>(Status::CODE_500, "application/json; charset=utf-8");
     }
-    ENDPOINT("GET", "/api/v1/sound/{filename}", getSound, PATH(String, filename)) {
-
+    ENDPOINT("GET", "/api/v1/sound/{filename}", getSound, PATH(String, filename),
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
         debug("Request to serve sound file: {}", std::string(filename));
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
+        return runEndpoint("GET /api/v1/sound/{filename}", "GET", "/api/v1/sound/" + std::string(filename), "getSound",
+                           "SoundController", request, [&](const auto &span) {
+                               // Sanitize the filename
+                               std::string safeFilename;
+                               try {
+                                   safeFilename = sanitizeFilename(filename);
+                               } catch (const std::invalid_argument &e) {
+                                   warn("Attempt to serve {} failed: {}", std::string(filename), e.what());
+                                   auto response = StatusDto::createShared();
+                                   response->status = "Forbidden";
+                                   response->message = e.what();
+                                   response->code = 403;
+                                   if (span)
+                                       span->setHttpStatus(403);
+                                   return createDtoResponse(Status::CODE_403, response);
+                               }
 
-        // Sanitize the filename
-        std::string safeFilename;
-        try {
-            safeFilename = sanitizeFilename(filename);
-        } catch (const std::invalid_argument &e) {
+                               // Assemble the path
+                               auto filePath = config->getSoundFileLocation() + "/" + safeFilename;
 
-            warn("Attempt to serve {} failed: {}", std::string(filename), e.what());
+                               // Resolve the canonical path
+                               std::filesystem::path canonicalPath;
+                               std::filesystem::path baseDir;
+                               try {
+                                   canonicalPath = std::filesystem::canonical(filePath);
+                                   baseDir = std::filesystem::canonical(config->getSoundFileLocation());
+                               } catch (const std::filesystem::filesystem_error &e) {
+                                   warn("Attempt to serve {} failed: {}", std::string(filename), e.what());
+                                   auto response = StatusDto::createShared();
+                                   response->status = "Not Found";
+                                   response->message = e.what();
+                                   response->code = 404;
+                                   if (span)
+                                       span->setHttpStatus(404);
+                                   return createDtoResponse(Status::CODE_404, response);
+                               }
 
-            auto response = StatusDto::createShared();
-            response->status = "Forbidden";
-            response->message = e.what();
-            response->code = 403;
-            return createDtoResponse(Status::CODE_403, response);
-        }
+                               // Ensure the resolved path is within the base directory
+                               if (canonicalPath.string().find(baseDir.string()) != 0) {
+                                   warn("Attempt to serve {} failed: {}", std::string(filename),
+                                        "Path traversal attempt.");
+                                   auto response = StatusDto::createShared();
+                                   response->status = "Forbidden";
+                                   response->message = "Forbidden: Path traversal attempt.";
+                                   response->code = 403;
+                                   if (span)
+                                       span->setHttpStatus(403);
+                                   return createDtoResponse(Status::CODE_403, response);
+                               }
 
-        // Assemble the path
-        auto filePath = config->getSoundFileLocation() + "/" + safeFilename;
+                               std::ifstream file(canonicalPath.string(), std::ios::binary | std::ios::ate);
+                               if (!file.is_open()) {
+                                   info("Attempt to serve {} failed: {}", std::string(filename), "Not found.");
+                                   auto response = StatusDto::createShared();
+                                   response->status = "Not Found";
+                                   response->message = "File not found.";
+                                   response->code = 404;
+                                   if (span)
+                                       span->setHttpStatus(404);
+                                   return createDtoResponse(Status::CODE_404, response);
+                               }
 
-        // Resolve the canonical path
-        std::filesystem::path canonicalPath;
-        std::filesystem::path baseDir;
-        try {
-            // Try to resolve canonical paths
-            canonicalPath = std::filesystem::canonical(filePath);
-            baseDir = std::filesystem::canonical(config->getSoundFileLocation());
-        } catch (const std::filesystem::filesystem_error &e) {
+                               std::streamsize fileSize = file.tellg();
+                               file.seekg(0, std::ios::beg);
+                               auto mimeType = getMimeType(filePath);
 
-            warn("Attempt to serve {} failed: {}", std::string(filename), e.what());
+                               std::vector<char> buffer(fileSize);
+                               if (!file.read(buffer.data(), fileSize)) {
+                                   auto response = StatusDto::createShared();
+                                   response->status = "Internal Server Error";
+                                   response->message = "Error reading file.";
+                                   response->code = 500;
+                                   if (span)
+                                       span->setHttpStatus(500);
+                                   return createDtoResponse(Status::CODE_500, response);
+                               }
 
-            auto response = StatusDto::createShared();
-            response->status = "Not Found";
-            response->message = e.what();
-            response->code = 404;
-            return createDtoResponse(Status::CODE_404, response);
-        }
+                               metrics->incrementSoundFilesServed();
+                               info("Serving sound file: {} ({}, {} bytes)", std::string(filename), mimeType, fileSize);
 
-        // Ensure the resolved path is within the base directory
-        if (canonicalPath.string().find(baseDir.string()) != 0) {
-
-            warn("Attempt to serve {} failed: {}", std::string(filename), "Path traversal attempt.");
-
-            auto response = StatusDto::createShared();
-            response->status = "Forbidden";
-            response->message = "Forbidden: Path traversal attempt.";
-            response->code = 403;
-            return createDtoResponse(Status::CODE_403, response);
-        }
-
-        // Open the file
-        std::ifstream file(canonicalPath.string(), std::ios::binary | std::ios::ate);
-        if (!file.is_open()) {
-
-            info("Attempt to serve {} failed: {}", std::string(filename), "Not found.");
-
-            auto response = StatusDto::createShared();
-            response->status = "Not Found";
-            response->message = "File not found.";
-            response->code = 404;
-            return createDtoResponse(Status::CODE_404, response);
-        }
-
-        // Get file size
-        std::streamsize fileSize = file.tellg();
-        file.seekg(0, std::ios::beg); // Go back to the start of the file
-
-        // Get MIME type
-        auto mimeType = getMimeType(filePath);
-
-        // Read file content
-        std::vector<char> buffer(fileSize);
-        if (!file.read(buffer.data(), fileSize)) {
-
-            auto response = StatusDto::createShared();
-            response->status = "Internal Server Error";
-            response->message = "Error reading file.";
-            response->code = 500;
-            return createDtoResponse(Status::CODE_500, response);
-        }
-
-        // Increment metrics and log
-        metrics->incrementSoundFilesServed();
-        info("Serving sound file: {} ({}, {} bytes)", std::string(filename), mimeType, fileSize);
-
-        // Create response
-        auto response =
-            ResponseFactory::createResponse(Status::CODE_200, oatpp::String((const char *)buffer.data(), fileSize));
-        response->putHeader("Content-Type", mimeType.c_str());
-        // content-length is automatically added by oatpp
-        return response;
+                               auto response = ResponseFactory::createResponse(
+                                   Status::CODE_200, oatpp::String((const char *)buffer.data(), fileSize));
+                               response->putHeader("Content-Type", mimeType.c_str());
+                               if (span)
+                                   span->setHttpStatus(200);
+                               return response;
+                           });
     }
 
     ENDPOINT_INFO(getAdHocSound) {
@@ -512,61 +499,66 @@ class SoundController : public oatpp::web::server::api::ApiController {
         info->addResponse<Object<StatusDto>>(Status::CODE_404, "application/json; charset=utf-8");
         info->addResponse<Object<StatusDto>>(Status::CODE_500, "application/json; charset=utf-8");
     }
-    ENDPOINT("GET", "api/v1/sound/ad-hoc/{filename}", getAdHocSound, PATH(String, filename)) {
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
+    ENDPOINT("GET", "api/v1/sound/ad-hoc/{filename}", getAdHocSound, PATH(String, filename),
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint("GET /api/v1/sound/ad-hoc/{filename}", "GET", "api/v1/sound/ad-hoc/" + std::string(filename),
+                           "getAdHocSound", "SoundController", request, [&](const auto &span) {
+                               std::string safeFilename;
+                               try {
+                                   safeFilename = sanitizeFilename(filename);
+                               } catch (const std::invalid_argument &e) {
+                                   auto response = StatusDto::createShared();
+                                   response->status = "Forbidden";
+                                   response->message = e.what();
+                                   response->code = 403;
+                                   if (span)
+                                       span->setHttpStatus(403);
+                                   return createDtoResponse(Status::CODE_403, response);
+                               }
 
-        std::string safeFilename;
-        try {
-            safeFilename = sanitizeFilename(filename);
-        } catch (const std::invalid_argument &e) {
-            auto response = StatusDto::createShared();
-            response->status = "Forbidden";
-            response->message = e.what();
-            response->code = 403;
-            return createDtoResponse(Status::CODE_403, response);
-        }
+                               std::string filePath;
+                               try {
+                                   filePath = m_soundService.resolveAdHocSoundPath(safeFilename);
+                               } catch (oatpp::web::protocol::http::HttpError &err) {
+                                   // withSpanStatus catches HttpError and stamps the right code; rethrow.
+                                   throw;
+                               }
 
-        std::string filePath;
-        try {
-            filePath = m_soundService.resolveAdHocSoundPath(safeFilename);
-        } catch (oatpp::web::protocol::http::HttpError &err) {
-            auto info = err.getInfo();
-            auto response = StatusDto::createShared();
-            response->status = std::string(Status(info.status).description);
-            response->message = err.getMessage();
-            response->code = info.status.code;
-            return createDtoResponse(Status(info.status), response);
-        }
+                               std::ifstream file(filePath, std::ios::binary | std::ios::ate);
+                               if (!file.is_open()) {
+                                   auto response = StatusDto::createShared();
+                                   response->status = "Not Found";
+                                   response->message = "File not found.";
+                                   response->code = 404;
+                                   if (span)
+                                       span->setHttpStatus(404);
+                                   return createDtoResponse(Status::CODE_404, response);
+                               }
 
-        std::ifstream file(filePath, std::ios::binary | std::ios::ate);
-        if (!file.is_open()) {
-            auto response = StatusDto::createShared();
-            response->status = "Not Found";
-            response->message = "File not found.";
-            response->code = 404;
-            return createDtoResponse(Status::CODE_404, response);
-        }
+                               std::streamsize fileSize = file.tellg();
+                               file.seekg(0, std::ios::beg);
 
-        std::streamsize fileSize = file.tellg();
-        file.seekg(0, std::ios::beg);
+                               std::vector<char> buffer(fileSize);
+                               if (!file.read(buffer.data(), fileSize)) {
+                                   auto response = StatusDto::createShared();
+                                   response->status = "Internal Server Error";
+                                   response->message = "Error reading file.";
+                                   response->code = 500;
+                                   if (span)
+                                       span->setHttpStatus(500);
+                                   return createDtoResponse(Status::CODE_500, response);
+                               }
 
-        std::vector<char> buffer(fileSize);
-        if (!file.read(buffer.data(), fileSize)) {
-            auto response = StatusDto::createShared();
-            response->status = "Internal Server Error";
-            response->message = "Error reading file.";
-            response->code = 500;
-            return createDtoResponse(Status::CODE_500, response);
-        }
-
-        auto mimeType = getMimeType(filePath);
-        auto response =
-            ResponseFactory::createResponse(Status::CODE_200, oatpp::String((const char *)buffer.data(), fileSize));
-        response->putHeader("Content-Type", mimeType.c_str());
-        response->putHeader("Content-Disposition", "attachment; filename=\"" + safeFilename + "\"");
-        return response;
+                               auto mimeType = getMimeType(filePath);
+                               auto response = ResponseFactory::createResponse(
+                                   Status::CODE_200, oatpp::String((const char *)buffer.data(), fileSize));
+                               response->putHeader("Content-Type", mimeType.c_str());
+                               response->putHeader("Content-Disposition",
+                                                   "attachment; filename=\"" + safeFilename + "\"");
+                               if (span)
+                                   span->setHttpStatus(200);
+                               return response;
+                           });
     }
 
     ENDPOINT_INFO(generateLipSync) {
@@ -579,73 +571,52 @@ class SoundController : public oatpp::web::server::api::ApiController {
     }
     ENDPOINT("POST", "api/v1/sound/generate-lipsync", generateLipSync,
              BODY_DTO(Object<creatures::ws::GenerateLipSyncRequestDto>, requestBody),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
-
-        // Create a trace span for this request
-        const auto span = creatures::observability
-                              ? creatures::observability->createRequestSpan("POST /api/v1/sound/generate-lipsync",
-                                                                            "POST", "api/v1/sound/generate-lipsync",
-                                                                            extractTraceparent(request))
-                              : nullptr;
-
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
         info("REST call to generateLipSync (async)");
-        if (creatures::metrics) {
-            creatures::metrics->incrementRestRequestsProcessed();
-        }
+        return runEndpoint(
+            "POST /api/v1/sound/generate-lipsync", "POST", "api/v1/sound/generate-lipsync", "generateLipSync",
+            "SoundController", request, [&](const auto &span) {
+                if (span) {
+                    span->setAttribute("sound.file", std::string(requestBody->sound_file));
+                }
 
-        if (span) {
-            span->setAttribute("endpoint.name", "generateLipSync");
-            span->setAttribute("controller.name", "SoundController");
-            span->setAttribute("http.method", "POST");
-            span->setAttribute("http.target", "api/v1/sound/generate-lipsync");
+                auto soundFile = std::string(requestBody->sound_file);
+                bool allowOverwrite =
+                    requestBody->allow_overwrite ? static_cast<bool>(requestBody->allow_overwrite) : false;
 
-            // Add User-Agent if present
-            if (const auto userAgent = request->getHeader("User-Agent")) {
-                span->setAttribute("http.user_agent", std::string(userAgent));
-            }
+                // Encode details as JSON to include both filename and allow_overwrite flag
+                nlohmann::json jobDetails;
+                jobDetails["sound_file"] = soundFile;
+                jobDetails["allow_overwrite"] = allowOverwrite;
+                const std::string jobDetailsStr = jobDetails.dump();
 
-            // Add request details
-            span->setAttribute("sound.file", std::string(requestBody->sound_file));
-        }
+                debug("Creating lip sync job for sound file: {}, allow_overwrite: {}", soundFile, allowOverwrite);
+                std::string jobId =
+                    creatures::jobManager->createJob(creatures::jobs::JobType::LipSync, jobDetailsStr, span);
+                info("Created lip sync job with ID: {}", jobId);
 
-        auto soundFile = std::string(requestBody->sound_file);
-        bool allowOverwrite = requestBody->allow_overwrite ? static_cast<bool>(requestBody->allow_overwrite) : false;
+                if (span) {
+                    span->setAttribute("job.id", jobId);
+                }
 
-        // Create a job for the lip sync processing
-        // Encode details as JSON to include both filename and allow_overwrite flag
-        nlohmann::json jobDetails;
-        jobDetails["sound_file"] = soundFile;
-        jobDetails["allow_overwrite"] = allowOverwrite;
-        const std::string jobDetailsStr = jobDetails.dump();
+                debug("Queueing job {} for processing", jobId);
+                creatures::jobWorker->queueJob(jobId);
+                info("Job {} queued successfully", jobId);
 
-        debug("Creating lip sync job for sound file: {}, allow_overwrite: {}", soundFile, allowOverwrite);
-        std::string jobId =
-            creatures::jobManager->createJob(creatures::jobs::JobType::LipSync, jobDetailsStr, span);
-        info("Created lip sync job with ID: {}", jobId);
+                const auto response = JobCreatedDto::createShared();
+                response->job_id = jobId;
+                response->job_type = "lip-sync";
+                response->message = fmt::format("Lip sync job created for '{}'. Listen for job-progress and "
+                                                "job-complete WebSocket messages.",
+                                                soundFile);
 
-        if (span) {
-            span->setAttribute("job.id", jobId);
-        }
+                if (span) {
+                    span->setHttpStatus(202);
+                }
 
-        // Queue the job for processing
-        debug("Queueing job {} for processing", jobId);
-        creatures::jobWorker->queueJob(jobId);
-        info("Job {} queued successfully", jobId);
-
-        // Create the response DTO
-        const auto response = JobCreatedDto::createShared();
-        response->job_id = jobId;
-        response->job_type = "lip-sync";
-        response->message = fmt::format(
-            "Lip sync job created for '{}'. Listen for job-progress and job-complete WebSocket messages.", soundFile);
-
-        if (span) {
-            span->setHttpStatus(202);
-            span->setAttribute("success", true);
-        }
-
-        debug("Returning 202 Accepted with job ID: {}", jobId);
-        return createDtoResponse(Status::CODE_202, response);
+                debug("Returning 202 Accepted with job ID: {}", jobId);
+                return createDtoResponse(Status::CODE_202, response);
+            });
     }
 };
 

--- a/src/server/ws/controller/SpeechToTextController.h
+++ b/src/server/ws/controller/SpeechToTextController.h
@@ -11,13 +11,8 @@
 #include "server/ws/controller/ControllerUtils.h"
 #include "server/ws/dto/SpeechToTextDto.h"
 #include "server/ws/dto/StatusDto.h"
-#include "util/ObservabilityManager.h"
 
 #include OATPP_CODEGEN_BEGIN(ApiController)
-
-namespace creatures {
-extern std::shared_ptr<ObservabilityManager> observability;
-}
 
 namespace creatures::ws {
 
@@ -27,8 +22,8 @@ class SpeechToTextController : public oatpp::web::server::api::ApiController {
         : oatpp::web::server::api::ApiController(objectMapper) {}
 
   public:
-    static std::shared_ptr<SpeechToTextController>
-    createShared(OATPP_COMPONENT(std::shared_ptr<ObjectMapper>, objectMapper)) {
+    static std::shared_ptr<SpeechToTextController> createShared(OATPP_COMPONENT(std::shared_ptr<ObjectMapper>,
+                                                                                objectMapper)) {
         return std::make_shared<SpeechToTextController>(objectMapper);
     }
 
@@ -36,98 +31,99 @@ class SpeechToTextController : public oatpp::web::server::api::ApiController {
 
     ENDPOINT_INFO(transcribeAudio) {
         info->summary = "Transcribe 16kHz mono float32 PCM audio to text";
-        info->description =
-            "Accepts raw 16kHz mono float32 PCM audio as the request body. "
-            "Returns the transcribed text. Used by creature-listener to offload "
-            "STT from the Pi to the server's faster CPU.";
+        info->description = "Accepts raw 16kHz mono float32 PCM audio as the request body. "
+                            "Returns the transcribed text. Used by creature-listener to offload "
+                            "STT from the Pi to the server's faster CPU.";
         info->addTag("Speech-to-Text");
-        info->addResponse<Object<SpeechToTextResponseDto>>(Status::CODE_200,
-                                                            "application/json; charset=utf-8");
+        info->addResponse<Object<SpeechToTextResponseDto>>(Status::CODE_200, "application/json; charset=utf-8");
     }
-    ENDPOINT("POST", "api/v1/stt/transcribe", transcribeAudio,
-             BODY_STRING(String, body),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
+    ENDPOINT("POST", "api/v1/stt/transcribe", transcribeAudio, BODY_STRING(String, body),
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint(
+            "POST /api/v1/stt/transcribe", "POST", "api/v1/stt/transcribe", "transcribeAudio", "SpeechToTextController",
+            request, [&](const auto &span) {
+                auto startTime = std::chrono::steady_clock::now();
 
-        auto span = creatures::observability
-                        ? creatures::observability->createRequestSpan(
-                              "POST /api/v1/stt/transcribe", "POST",
-                              "api/v1/stt/transcribe", extractTraceparent(request))
-                        : nullptr;
-        addHttpRequestAttributes(span, request);
+                if (!body || body->empty()) {
+                    auto result = StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 400;
+                    result->message = "Request body is empty — send raw 16kHz mono float32 PCM audio";
+                    if (span) {
+                        span->setError("Empty body");
+                        span->setHttpStatus(400);
+                    }
+                    return createDtoResponse(Status::CODE_400, result);
+                }
 
-        auto startTime = std::chrono::steady_clock::now();
+                // Interpret the body as raw float32 samples
+                auto bodyData = body->data();
+                auto bodySize = body->size();
 
-        if (!body || body->empty()) {
-            auto result = StatusDto::createShared();
-            result->status = "error";
-            result->code = 400;
-            result->message = "Request body is empty — send raw 16kHz mono float32 PCM audio";
-            if (span) { span->setError("Empty body"); span->setHttpStatus(400); }
-            return createDtoResponse(Status::CODE_400, result);
-        }
+                if (bodySize % sizeof(float) != 0) {
+                    auto result = StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 400;
+                    result->message = "Body size is not a multiple of 4 bytes (expected float32 PCM)";
+                    if (span) {
+                        span->setError("Invalid body size");
+                        span->setHttpStatus(400);
+                    }
+                    return createDtoResponse(Status::CODE_400, result);
+                }
 
-        // Interpret the body as raw float32 samples
-        auto bodyData = body->data();
-        auto bodySize = body->size();
+                size_t numSamples = bodySize / sizeof(float);
+                const auto *floatData = reinterpret_cast<const float *>(bodyData);
+                std::vector<float> audioData(floatData, floatData + numSamples);
 
-        if (bodySize % sizeof(float) != 0) {
-            auto result = StatusDto::createShared();
-            result->status = "error";
-            result->code = 400;
-            result->message = "Body size is not a multiple of 4 bytes (expected float32 PCM)";
-            if (span) { span->setError("Invalid body size"); span->setHttpStatus(400); }
-            return createDtoResponse(Status::CODE_400, result);
-        }
+                float durationSec = static_cast<float>(numSamples) / 16000.0f;
+                info("STT request: {:.1f}s of audio ({} samples, {} bytes)", durationSec, numSamples, bodySize);
 
-        size_t numSamples = bodySize / sizeof(float);
-        const auto* floatData = reinterpret_cast<const float*>(bodyData);
-        std::vector<float> audioData(floatData, floatData + numSamples);
+                if (span) {
+                    span->setAttribute("audio.duration_sec", fmt::format("{:.1f}", durationSec));
+                    span->setAttribute("audio.samples", static_cast<int64_t>(numSamples));
+                }
 
-        float durationSec = static_cast<float>(numSamples) / 16000.0f;
-        info("STT request: {:.1f}s of audio ({} samples, {} bytes)",
-             durationSec, numSamples, bodySize);
+                // Transcribe using the shared whisper context
+                auto &processor = creatures::voice::WhisperLipSyncProcessor::instance();
+                auto operationSpan = (span && creatures::observability)
+                                         ? creatures::observability->createOperationSpan("stt.transcribe", span)
+                                         : nullptr;
+                auto transcribeResult = processor.transcribe(audioData, operationSpan);
 
-        if (span) {
-            span->setAttribute("audio.duration_sec", fmt::format("{:.1f}", durationSec));
-            span->setAttribute("audio.samples", static_cast<int64_t>(numSamples));
-        }
+                auto endTime = std::chrono::steady_clock::now();
+                double elapsedMs = std::chrono::duration<double, std::milli>(endTime - startTime).count();
 
-        // Transcribe using the shared whisper context
-        auto &processor = creatures::voice::WhisperLipSyncProcessor::instance();
-        auto operationSpan = (span && creatures::observability)
-            ? creatures::observability->createOperationSpan("stt.transcribe", span)
-            : nullptr;
-        auto transcribeResult = processor.transcribe(audioData, operationSpan);
+                if (!transcribeResult.isSuccess()) {
+                    auto result = StatusDto::createShared();
+                    result->status = "error";
+                    result->code = 500;
+                    result->message = transcribeResult.getError()->getMessage().c_str();
+                    if (span) {
+                        span->setError(transcribeResult.getError()->getMessage());
+                        span->setHttpStatus(500);
+                    }
+                    return createDtoResponse(Status::CODE_500, result);
+                }
 
-        auto endTime = std::chrono::steady_clock::now();
-        double elapsedMs = std::chrono::duration<double, std::milli>(endTime - startTime).count();
+                auto transcript = transcribeResult.getValue().value();
 
-        if (!transcribeResult.isSuccess()) {
-            auto result = StatusDto::createShared();
-            result->status = "error";
-            result->code = 500;
-            result->message = transcribeResult.getError()->getMessage().c_str();
-            if (span) { span->setError(transcribeResult.getError()->getMessage()); span->setHttpStatus(500); }
-            return createDtoResponse(Status::CODE_500, result);
-        }
+                auto response = SpeechToTextResponseDto::createShared();
+                response->status = "ok";
+                response->transcript = transcript.c_str();
+                response->audio_duration_sec = static_cast<double>(durationSec);
+                response->transcription_time_ms = elapsedMs;
 
-        auto transcript = transcribeResult.getValue().value();
+                if (span) {
+                    span->setAttribute("transcript.length", static_cast<int64_t>(transcript.size()));
+                    span->setAttribute("transcription.time_ms", fmt::format("{:.0f}", elapsedMs));
+                    span->setHttpStatus(200);
+                }
 
-        auto response = SpeechToTextResponseDto::createShared();
-        response->status = "ok";
-        response->transcript = transcript.c_str();
-        response->audio_duration_sec = static_cast<double>(durationSec);
-        response->transcription_time_ms = elapsedMs;
+                info("STT complete in {:.0f}ms: \"{}\"", elapsedMs, transcript);
 
-        if (span) {
-            span->setAttribute("transcript.length", static_cast<int64_t>(transcript.size()));
-            span->setAttribute("transcription.time_ms", fmt::format("{:.0f}", elapsedMs));
-            span->setHttpStatus(200);
-        }
-
-        info("STT complete in {:.0f}ms: \"{}\"", elapsedMs, transcript);
-
-        return createDtoResponse(Status::CODE_200, response);
+                return createDtoResponse(Status::CODE_200, response);
+            });
     }
 };
 

--- a/src/server/ws/controller/StreamingAdHocController.h
+++ b/src/server/ws/controller/StreamingAdHocController.h
@@ -7,15 +7,14 @@
 
 #include "server/namespace-stuffs.h"
 #include "server/voice/StreamingAdHocSession.h"
+#include "server/ws/controller/ControllerUtils.h"
 #include "server/ws/dto/StatusDto.h"
 #include "server/ws/dto/StreamingAdHocDto.h"
-#include "util/ObservabilityManager.h"
 
 #include OATPP_CODEGEN_BEGIN(ApiController)
 
 namespace creatures {
 extern std::shared_ptr<Configuration> config;
-extern std::shared_ptr<ObservabilityManager> observability;
 } // namespace creatures
 
 namespace creatures::ws {
@@ -25,8 +24,8 @@ class StreamingAdHocController : public oatpp::web::server::api::ApiController {
     StreamingAdHocController(OATPP_COMPONENT(std::shared_ptr<ObjectMapper>, objectMapper))
         : oatpp::web::server::api::ApiController(objectMapper) {}
 
-    static std::shared_ptr<StreamingAdHocController> createShared(
-        OATPP_COMPONENT(std::shared_ptr<ObjectMapper>, objectMapper)) {
+    static std::shared_ptr<StreamingAdHocController> createShared(OATPP_COMPONENT(std::shared_ptr<ObjectMapper>,
+                                                                                  objectMapper)) {
         return std::make_shared<StreamingAdHocController>(objectMapper);
     }
 
@@ -37,55 +36,56 @@ class StreamingAdHocController : public oatpp::web::server::api::ApiController {
         info->description = "Creates a session that accumulates text chunks from the agent. "
                             "Call /text to add sentences, then /finish to synthesize and play.";
         info->addTag("Streaming Ad-Hoc Speech");
-        info->addResponse<Object<StreamingAdHocStartResponseDto>>(Status::CODE_200,
-                                                                    "application/json; charset=utf-8");
+        info->addResponse<Object<StreamingAdHocStartResponseDto>>(Status::CODE_200, "application/json; charset=utf-8");
     }
     ENDPOINT("POST", "api/v1/animation/ad-hoc-stream/start", startStreamingAdHoc,
              BODY_DTO(Object<StreamingAdHocStartRequestDto>, requestBody),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint("POST /api/v1/animation/ad-hoc-stream/start", "POST", "api/v1/animation/ad-hoc-stream/start",
+                           "startStreamingAdHoc", "StreamingAdHocController", request, [&](const auto &span) {
+                               auto creatureId = requestBody->creature_id;
+                               bool resumePlaylist =
+                                   requestBody->resume_playlist != nullptr ? *requestBody->resume_playlist : true;
 
-        auto span = creatures::observability
-                        ? creatures::observability->createRequestSpan(
-                              "POST /api/v1/animation/ad-hoc-stream/start", "POST",
-                              "api/v1/animation/ad-hoc-stream/start", extractTraceparent(request))
-                        : nullptr;
-        addHttpRequestAttributes(span, request);
+                               if (!creatureId || creatureId->empty()) {
+                                   auto result = StatusDto::createShared();
+                                   result->status = "error";
+                                   result->code = 400;
+                                   result->message = "creature_id is required";
+                                   if (span)
+                                       span->setHttpStatus(400);
+                                   return createDtoResponse(Status::CODE_400, result);
+                               }
 
-        auto creatureId = requestBody->creature_id;
-        bool resumePlaylist = requestBody->resume_playlist != nullptr ? *requestBody->resume_playlist : true;
+                               auto &mgr = creatures::voice::StreamingAdHocSessionManager::instance();
+                               auto session = mgr.createSession(creatureId->c_str(), resumePlaylist, span);
 
-        if (!creatureId || creatureId->empty()) {
-            auto result = StatusDto::createShared();
-            result->status = "error";
-            result->code = 400;
-            result->message = "creature_id is required";
-            return createDtoResponse(Status::CODE_400, result);
-        }
+                               auto startResult = session->start();
+                               if (!startResult.isSuccess()) {
+                                   mgr.removeSession(session->getSessionId());
+                                   auto result = StatusDto::createShared();
+                                   result->status = "error";
+                                   result->code = 500;
+                                   result->message = startResult.getError()->getMessage().c_str();
+                                   if (span) {
+                                       span->setError(startResult.getError()->getMessage());
+                                       span->setHttpStatus(500);
+                                   }
+                                   return createDtoResponse(Status::CODE_500, result);
+                               }
 
-        auto &mgr = creatures::voice::StreamingAdHocSessionManager::instance();
-        auto session = mgr.createSession(creatureId->c_str(), resumePlaylist, span);
+                               auto response = StreamingAdHocStartResponseDto::createShared();
+                               response->session_id = session->getSessionId().c_str();
+                               response->status = "started";
+                               response->message = "Session started. Send text chunks via /text, then call /finish.";
 
-        auto startResult = session->start();
-        if (!startResult.isSuccess()) {
-            mgr.removeSession(session->getSessionId());
-            auto result = StatusDto::createShared();
-            result->status = "error";
-            result->code = 500;
-            result->message = startResult.getError()->getMessage().c_str();
-            return createDtoResponse(Status::CODE_500, result);
-        }
+                               if (span) {
+                                   span->setAttribute("session.id", session->getSessionId());
+                                   span->setHttpStatus(200);
+                               }
 
-        auto response = StreamingAdHocStartResponseDto::createShared();
-        response->session_id = session->getSessionId().c_str();
-        response->status = "started";
-        response->message = "Session started. Send text chunks via /text, then call /finish.";
-
-        if (span) {
-            span->setAttribute("session.id", session->getSessionId());
-            span->setHttpStatus(200);
-        }
-
-        return createDtoResponse(Status::CODE_200, response);
+                               return createDtoResponse(Status::CODE_200, response);
+                           });
     }
 
     // --- Add text to a session ---
@@ -94,62 +94,64 @@ class StreamingAdHocController : public oatpp::web::server::api::ApiController {
         info->summary = "Add a text chunk to a streaming session";
         info->description = "Adds a sentence or text fragment to the session's speech buffer.";
         info->addTag("Streaming Ad-Hoc Speech");
-        info->addResponse<Object<StreamingAdHocTextResponseDto>>(Status::CODE_200,
-                                                                   "application/json; charset=utf-8");
+        info->addResponse<Object<StreamingAdHocTextResponseDto>>(Status::CODE_200, "application/json; charset=utf-8");
     }
     ENDPOINT("POST", "api/v1/animation/ad-hoc-stream/text", addStreamingAdHocText,
              BODY_DTO(Object<StreamingAdHocTextRequestDto>, requestBody),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint("POST /api/v1/animation/ad-hoc-stream/text", "POST", "api/v1/animation/ad-hoc-stream/text",
+                           "addStreamingAdHocText", "StreamingAdHocController", request, [&](const auto &span) {
+                               auto sessionId = requestBody->session_id;
+                               auto text = requestBody->text;
 
-        auto span = creatures::observability
-                        ? creatures::observability->createRequestSpan(
-                              "POST /api/v1/animation/ad-hoc-stream/text", "POST",
-                              "api/v1/animation/ad-hoc-stream/text", extractTraceparent(request))
-                        : nullptr;
-        addHttpRequestAttributes(span, request);
+                               if (!sessionId || sessionId->empty() || !text || text->empty()) {
+                                   auto result = StatusDto::createShared();
+                                   result->status = "error";
+                                   result->code = 400;
+                                   result->message = "session_id and text are required";
+                                   if (span)
+                                       span->setHttpStatus(400);
+                                   return createDtoResponse(Status::CODE_400, result);
+                               }
 
-        auto sessionId = requestBody->session_id;
-        auto text = requestBody->text;
+                               auto &mgr = creatures::voice::StreamingAdHocSessionManager::instance();
+                               auto session = mgr.getSession(sessionId->c_str());
+                               if (!session) {
+                                   auto result = StatusDto::createShared();
+                                   result->status = "error";
+                                   result->code = 404;
+                                   result->message = "Session not found";
+                                   if (span)
+                                       span->setHttpStatus(404);
+                                   return createDtoResponse(Status::CODE_404, result);
+                               }
 
-        if (!sessionId || sessionId->empty() || !text || text->empty()) {
-            auto result = StatusDto::createShared();
-            result->status = "error";
-            result->code = 400;
-            result->message = "session_id and text are required";
-            return createDtoResponse(Status::CODE_400, result);
-        }
+                               auto addResult = session->addText(text->c_str());
+                               if (!addResult.isSuccess()) {
+                                   auto result = StatusDto::createShared();
+                                   result->status = "error";
+                                   result->code = 500;
+                                   result->message = addResult.getError()->getMessage().c_str();
+                                   if (span) {
+                                       span->setError(addResult.getError()->getMessage());
+                                       span->setHttpStatus(500);
+                                   }
+                                   return createDtoResponse(Status::CODE_500, result);
+                               }
 
-        auto &mgr = creatures::voice::StreamingAdHocSessionManager::instance();
-        auto session = mgr.getSession(sessionId->c_str());
-        if (!session) {
-            auto result = StatusDto::createShared();
-            result->status = "error";
-            result->code = 404;
-            result->message = "Session not found";
-            return createDtoResponse(Status::CODE_404, result);
-        }
+                               auto response = StreamingAdHocTextResponseDto::createShared();
+                               response->session_id = sessionId;
+                               response->status = "ok";
+                               response->chunks_received = session->getChunksReceived();
 
-        auto addResult = session->addText(text->c_str());
-        if (!addResult.isSuccess()) {
-            auto result = StatusDto::createShared();
-            result->status = "error";
-            result->code = 500;
-            result->message = addResult.getError()->getMessage().c_str();
-            return createDtoResponse(Status::CODE_500, result);
-        }
+                               if (span) {
+                                   span->setAttribute("session.id", std::string(sessionId->c_str()));
+                                   span->setAttribute("text.length", static_cast<int64_t>(text->size()));
+                                   span->setHttpStatus(200);
+                               }
 
-        auto response = StreamingAdHocTextResponseDto::createShared();
-        response->session_id = sessionId;
-        response->status = "ok";
-        response->chunks_received = session->getChunksReceived();
-
-        if (span) {
-            span->setAttribute("session.id", std::string(sessionId->c_str()));
-            span->setAttribute("text.length", static_cast<int64_t>(text->size()));
-            span->setHttpStatus(200);
-        }
-
-        return createDtoResponse(Status::CODE_200, response);
+                               return createDtoResponse(Status::CODE_200, response);
+                           });
     }
 
     // --- Finish a session ---
@@ -159,89 +161,74 @@ class StreamingAdHocController : public oatpp::web::server::api::ApiController {
         info->description =
             "Sends all accumulated text to ElevenLabs, generates lip sync, builds animation, and plays it.";
         info->addTag("Streaming Ad-Hoc Speech");
-        info->addResponse<Object<StreamingAdHocFinishResponseDto>>(Status::CODE_200,
-                                                                     "application/json; charset=utf-8");
+        info->addResponse<Object<StreamingAdHocFinishResponseDto>>(Status::CODE_200, "application/json; charset=utf-8");
     }
     ENDPOINT("POST", "api/v1/animation/ad-hoc-stream/finish", finishStreamingAdHoc,
              BODY_DTO(Object<StreamingAdHocFinishRequestDto>, requestBody),
-             REQUEST(std::shared_ptr<oatpp::web::protocol::http::incoming::Request>, request)) {
+             REQUEST(std::shared_ptr<IncomingRequest>, request)) {
+        return runEndpoint("POST /api/v1/animation/ad-hoc-stream/finish", "POST",
+                           "api/v1/animation/ad-hoc-stream/finish", "finishStreamingAdHoc", "StreamingAdHocController",
+                           request, [&](const auto &span) {
+                               auto sessionId = requestBody->session_id;
 
-        auto span = creatures::observability
-                        ? creatures::observability->createRequestSpan(
-                              "POST /api/v1/animation/ad-hoc-stream/finish", "POST",
-                              "api/v1/animation/ad-hoc-stream/finish", extractTraceparent(request))
-                        : nullptr;
-        addHttpRequestAttributes(span, request);
+                               if (!sessionId || sessionId->empty()) {
+                                   auto result = StatusDto::createShared();
+                                   result->status = "error";
+                                   result->code = 400;
+                                   result->message = "session_id is required";
+                                   if (span)
+                                       span->setHttpStatus(400);
+                                   return createDtoResponse(Status::CODE_400, result);
+                               }
 
-        auto sessionId = requestBody->session_id;
+                               auto &mgr = creatures::voice::StreamingAdHocSessionManager::instance();
+                               auto session = mgr.getSession(sessionId->c_str());
+                               if (!session) {
+                                   auto result = StatusDto::createShared();
+                                   result->status = "error";
+                                   result->code = 404;
+                                   result->message = "Session not found";
+                                   if (span)
+                                       span->setHttpStatus(404);
+                                   return createDtoResponse(Status::CODE_404, result);
+                               }
 
-        if (!sessionId || sessionId->empty()) {
-            auto result = StatusDto::createShared();
-            result->status = "error";
-            result->code = 400;
-            result->message = "session_id is required";
-            return createDtoResponse(Status::CODE_400, result);
-        }
+                               auto finishResult = session->finish();
 
-        auto &mgr = creatures::voice::StreamingAdHocSessionManager::instance();
-        auto session = mgr.getSession(sessionId->c_str());
-        if (!session) {
-            auto result = StatusDto::createShared();
-            result->status = "error";
-            result->code = 404;
-            result->message = "Session not found";
-            return createDtoResponse(Status::CODE_404, result);
-        }
+                               // Safe to remove now — finish() completes all TTS and animation
+                               // construction before returning. Playback is triggered via interrupt()
+                               // which creates its own PlaybackSession with its own lifecycle.
+                               mgr.removeSession(sessionId->c_str());
 
-        auto finishResult = session->finish();
+                               if (!finishResult.isSuccess()) {
+                                   auto result = StatusDto::createShared();
+                                   result->status = "error";
+                                   result->code = 500;
+                                   result->message = finishResult.getError()->getMessage().c_str();
+                                   if (span) {
+                                       span->setError(finishResult.getError()->getMessage());
+                                       span->setHttpStatus(500);
+                                   }
+                                   return createDtoResponse(Status::CODE_500, result);
+                               }
 
-        // Safe to remove now — finish() completes all TTS and animation construction
-        // before returning. Playback is triggered via interrupt() which creates its
-        // own PlaybackSession with its own lifecycle.
-        mgr.removeSession(sessionId->c_str());
+                               auto animationId = finishResult.getValue().value();
 
-        if (!finishResult.isSuccess()) {
-            auto result = StatusDto::createShared();
-            result->status = "error";
-            result->code = 500;
-            result->message = finishResult.getError()->getMessage().c_str();
-            if (span) {
-                span->setError(finishResult.getError()->getMessage());
-                span->setHttpStatus(500);
-            }
-            return createDtoResponse(Status::CODE_500, result);
-        }
+                               auto response = StreamingAdHocFinishResponseDto::createShared();
+                               response->session_id = sessionId;
+                               response->status = "completed";
+                               response->message = "Speech generated and playback triggered";
+                               response->animation_id = animationId.c_str();
+                               response->playback_triggered = true;
 
-        auto animationId = finishResult.getValue().value();
+                               if (span) {
+                                   span->setAttribute("session.id", std::string(sessionId->c_str()));
+                                   span->setAttribute("animation.id", animationId);
+                                   span->setHttpStatus(200);
+                               }
 
-        auto response = StreamingAdHocFinishResponseDto::createShared();
-        response->session_id = sessionId;
-        response->status = "completed";
-        response->message = "Speech generated and playback triggered";
-        response->animation_id = animationId.c_str();
-        response->playback_triggered = true;
-
-        if (span) {
-            span->setAttribute("session.id", std::string(sessionId->c_str()));
-            span->setAttribute("animation.id", animationId);
-            span->setHttpStatus(200);
-        }
-
-        return createDtoResponse(Status::CODE_200, response);
-    }
-
-  private:
-    static std::string extractTraceparent(
-        const std::shared_ptr<oatpp::web::protocol::http::incoming::Request> &request) {
-        auto header = request->getHeader("traceparent");
-        return header ? std::string(header->c_str()) : "";
-    }
-
-    static void addHttpRequestAttributes(std::shared_ptr<creatures::RequestSpan> span,
-                                          const std::shared_ptr<oatpp::web::protocol::http::incoming::Request> &request) {
-        if (!span) return;
-        span->setAttribute("http.method", std::string(request->getStartingLine().method.std_str()));
-        span->setAttribute("http.url", std::string(request->getStartingLine().path.std_str()));
+                               return createDtoResponse(Status::CODE_200, response);
+                           });
     }
 };
 


### PR DESCRIPTION
## Summary

Follow-up to [PR #7](https://github.com/opsnlops/creature-server/pull/7), closing the O-H2 item from [`docs/audit-2026-05-23.md`](docs/audit-2026-05-23.md).

PR #7 introduced the `runEndpoint(...)` helper and applied it to the 5 controllers that had no `RequestSpan` at all. This PR finishes the job: the other 5 controllers (`CreatureController`, `AnimationController`, `SoundController`, `SpeechToTextController`, `StreamingAdHocController`) had spans but used the legacy `setHttpStatus(200)` outside try/catch pattern — which meant a throwing service let the `RequestSpan` destructor default to 200, silently dropping real 4xx/5xx from Honeycomb's `http.status_code` column. All 29 endpoints across the 5 controllers are now wrapped in `runEndpoint(...)`, so `withSpanStatus` correctly catches exceptions and stamps the right status before rethrowing.

## Side benefits picked up along the way

- **`StreamingAdHocController`** dropped its private `extractTraceparent` / `addHttpRequestAttributes` copies and now uses the shared `ControllerUtils.h` versions (one source of truth).
- **`CreatureController`** gained UUID-shape validation on the `creatureId` path param, matching the existing pattern in `DmxFixtureController`.
- A few duplicate `if (creatures::metrics) { if (creatures::metrics) { ... } }` copy-paste bugs in `CreatureController` and `SoundController` went away as a side effect of pulling the metric increment into the helper.
- Several unused `extern std::shared_ptr<ObservabilityManager> observability` declarations in the migrated headers got pruned (already declared in `ControllerUtils.h`).

## Diff shape

5 files, **+1454 / -1750** (net **-296** lines). Most of the deletion is consolidated boilerplate.

## Test plan

- [x] Local macOS build (clang, Debug): 0 our-code warnings
- [x] Production Docker build (Debian trixie + clang-19, Release): 0 our-code warnings
- [x] Local unit tests: 50/50 pass
- [x] Container `ctest`: 60/60 pass
- [ ] CI build passes on this PR
- [ ] Manual: hit a representative endpoint from each migrated controller and confirm spans land in Honeycomb with the right `http.status_code` (both 200 and an error case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)