### PR TITLE
Speed up CI: split deps into cached layer + GHA build cache

### DIFF
--- a/.github/workflows/amd64.yml
+++ b/.github/workflows/amd64.yml
@@ -29,4 +29,9 @@ jobs:
           push: true
           target: runtime
           tags: ${{ secrets.DOCKER_LOGIN_USERNAME }}/creature-server:amd64
+          # GHA build cache. Combined with the split-stage Dockerfile
+          # (deps in a stable layer), typical source-change PRs reuse
+          # cached layers and finish in ~2 min instead of ~15. See #13.
+          cache-from: type=gha,scope=amd64
+          cache-to: type=gha,mode=max,scope=amd64
   

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -29,3 +29,7 @@ jobs:
           push: true
           target: runtime
           tags: ${{ secrets.DOCKER_LOGIN_USERNAME }}/creature-server:arm64
+          # GHA build cache. Scoped per-arch so amd64 + arm64 don't trample
+          # each other's layer cache. See #13.
+          cache-from: type=gha,scope=arm64
+          cache-to: type=gha,mode=max,scope=arm64

--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -21,8 +21,25 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # docker/build-push-action + GHA cache. Combined with the split-stage
+      # Dockerfile (deps in a stable layer that only invalidates on
+      # CMakeLists.txt / cmake/ / lib/ / externals/ / build_oatpp.sh
+      # changes), typical source-change PRs reuse cached layers and rebuild
+      # in ~2 min instead of ~15. Scope is per-OS so amd64 + arm64 matrix
+      # don't trample each other. See issue #13.
       - name: Build in container
-        run: docker build -f ${{github.workspace}}/Dockerfile . --target package -t temp-image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{github.workspace}}/Dockerfile
+          target: package
+          tags: temp-image
+          load: true
+          cache-from: type=gha,scope=package-${{ matrix.os }}
+          cache-to: type=gha,mode=max,scope=package-${{ matrix.os }}
 
       - name: Build temp container
         run: docker create --name temp-container temp-image

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,25 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # Build via docker/build-push-action so we can wire up the GitHub
+      # Actions build cache (cache-from / cache-to type=gha). Combined with
+      # the Dockerfile's split-stage layout (deps in their own layer that
+      # only invalidates on CMakeLists.txt / cmake/ / externals/ changes),
+      # a typical source-change PR re-uses the cached deps layer and only
+      # the final `ninja` re-runs — drops ~15 min to ~2 min. See issue #13.
       - name: Build test image
-        run: docker build -f Dockerfile . --target build -t creature-server-buildtest
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: build
+          tags: creature-server-buildtest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run ctest (skip vendor mongo driver fixtures)
         run: docker run --rm creature-server-buildtest ctest -E "${CTEST_EXCLUDE}" --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,41 @@ add_definitions(
 add_subdirectory(lib/e131_service)
 add_subdirectory(lib/CreatureVoicesLib)
 
+# Umbrella target for the Docker build to pre-compile every heavy FetchContent
+# library before src/ is COPYed into the image. The Dockerfile runs
+# `ninja deps_only` in a stable layer (only invalidated when CMakeLists.txt /
+# cmake/ / lib/ / externals/ change), then copies src/ + tests/ and runs the
+# final `ninja` — which finds all the dep .o files already on disk and only
+# rebuilds the project's own sources. Cuts typical PR build time from ~15 min
+# to ~2 min. See issue #13.
+#
+# Target names verified against `ninja -t targets all` in an existing build.
+# Header-only libraries (nlohmann_json, argparse) are excluded — nothing to
+# pre-compile. mongoc_static / bson_static are dependencies of mongocxx_static
+# but listed explicitly for clarity in build logs.
+add_custom_target(deps_only DEPENDS
+        mongocxx_static
+        mongoc_static
+        bsoncxx_static
+        bson_static
+        fmt
+        spdlog
+        opus
+        uvgrtp
+        whisper
+        ggml
+        opentelemetry_trace
+        opentelemetry_metrics
+        opentelemetry_logs
+        opentelemetry_resources
+        opentelemetry_common
+        opentelemetry_http_client_curl
+        opentelemetry_exporter_otlp_http
+        opentelemetry_exporter_otlp_http_metric
+        gtest_main
+        gmock_main
+)
+
 #Set up a base64 encoder / decoder
 set(LIBBASE64_DIR "${CMAKE_SOURCE_DIR}/lib/base64")
 
@@ -361,6 +396,14 @@ include_directories(
         ${oatpp_INCLUDE_DIRS}
         PRIVATE ${CMAKE_BINARY_DIR}
 )
+
+# Skip the executable + test target definitions when src/ + tests/ aren't
+# present. Lets the Dockerfile do a Phase 1 cmake configure with empty src/
+# (only cmake/ + lib/ + externals/ + CMakeLists.txt + build_oatpp.sh COPYed)
+# to pre-build the deps_only umbrella target in a cacheable layer. Phase 2
+# COPYs src/ + tests/ and re-runs cmake — these blocks then activate and
+# the real build happens against already-compiled deps. See issue #13.
+if (EXISTS ${CMAKE_SOURCE_DIR}/src/server/main.cpp)
 
 add_executable(creature-server
         ${serverFiles}
@@ -554,11 +597,15 @@ install(TARGETS creature-server
         DESTINATION "/bin"
 )
 
+endif() # EXISTS src/server/main.cpp
+
 #
 # Set up testing
 #
 
 enable_testing()
+
+if (EXISTS ${CMAKE_SOURCE_DIR}/tests/server/TestGlobals.cpp)
 
 add_executable(creature-server-test
         tests/model/Creature_test.cpp
@@ -652,6 +699,8 @@ set_property(TARGET creature-server-test PROPERTY FOLDER "tests")
 # Register the test with CTest
 include(GoogleTest)
 gtest_discover_tests(creature-server-test)
+
+endif() # EXISTS tests/server/TestGlobals.cpp
 
 # where to find our CMake modules
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,41 +26,63 @@ RUN apt install -y \
         util-linux \
         uuid-dev
 
-
-
-# Build our stuff
-RUN mkdir -p /build/creature-server/src
-COPY src/ /build/creature-server/src
-COPY cmake/ /build/creature-server/cmake
-COPY lib/ /build/creature-server/lib
-COPY tests/ /build/creature-server/tests
-COPY externals/ /build/creature-server/externals
-COPY LICENSE README.md CMakeLists.txt build_oatpp.sh /build/creature-server/
-RUN ls -lart /build/creature-server/
-
-# Clone missing git submodule (base64) if not already present
-RUN if [ ! -f /build/creature-server/lib/base64/include/base64.hpp ]; then \
-        git clone https://github.com/tobiaslocker/base64.git /build/creature-server/lib/base64; \
-    fi
-
 # Use the clang-19 we installed above (without this, CMake picks Debian's default gcc)
 ENV CC=clang-19
 ENV CXX=clang++-19
 
-# Install the externals
+# ---- Phase 1: build oatpp + all FetchContent dependencies in a layer that
+# only invalidates when CMakeLists.txt / cmake/ / lib/ / externals/ / the
+# oatpp build script change. The heavy compile (Mongo C/C++ driver, OTel,
+# whisper, opus, uvgrtp, googletest, fmt, spdlog) lands here and gets reused
+# by every subsequent build that doesn't change those inputs. See issue #13.
+
+RUN mkdir -p /build/creature-server
+COPY cmake/ /build/creature-server/cmake
+COPY lib/ /build/creature-server/lib
+COPY externals/ /build/creature-server/externals
+COPY LICENSE README.md CMakeLists.txt build_oatpp.sh /build/creature-server/
+
+# CMakeLists.txt's top-level configure_file() needs this template at configure
+# time (see CMakeLists.txt:27). Pulled in by itself in Phase 1 so we don't have
+# to COPY src/ wholesale just for one file — that'd defeat the cache split.
+COPY src/server/Version.h.in /build/creature-server/src/server/Version.h.in
+
+# Clone the base64 lib if not already present (lib/base64 might be in-tree
+# or might need fetching depending on how the workspace was set up).
+RUN if [ ! -f /build/creature-server/lib/base64/include/base64.hpp ]; then \
+        git clone https://github.com/tobiaslocker/base64.git /build/creature-server/lib/base64; \
+    fi
+
+# Build oatpp into externals/install.
 RUN cd /build/creature-server/ && ./build_oatpp.sh
 
-# Build the server
+# Configure CMake. file(GLOB serverFiles src/...) returns an empty list at
+# this stage (src/ doesn't exist yet) but configure succeeds — add_executable
+# doesn't check source-file existence, only the build does. We're not going
+# to build the executable in this layer.
 RUN cd /build/creature-server && \
-    mkdir build && \
-    cd build && \
+    mkdir build && cd build && \
     cmake -DCMAKE_MAKE_PROGRAM=ninja -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
           ..
 
-# Run the build in a different layer so we avoid grabbing the code over
-# and over again
-RUN cd /build/creature-server/build && ninja -j4
+# Pre-compile every heavy FetchContent dep via the deps_only umbrella target
+# (defined in CMakeLists.txt). This is the ~15 minute step today; with this
+# layer cached it only re-runs when CMakeLists / cmake / lib / externals /
+# build_oatpp.sh change.
+RUN cd /build/creature-server/build && ninja -j4 deps_only
+
+# ---- Phase 2: copy our source + build the final binary. Only this layer
+# re-runs on a typical "I changed a .cpp file" PR.
+
+COPY src/ /build/creature-server/src
+COPY tests/ /build/creature-server/tests
+
+# Re-run cmake configure so the file(GLOB) source-list calls re-evaluate
+# against the now-populated src/ tree. (Without this, ninja would still see
+# the empty-src configuration from Phase 1.) Configure is fast — a few seconds
+# — once the FetchContent sources are already populated.
+RUN cd /build/creature-server/build && cmake .. && ninja -j4
 
 
 # Now build a small runtime


### PR DESCRIPTION
Closes #13.

## What changes

**CMakeLists.txt**
- New \`add_custom_target(deps_only DEPENDS ...)\` umbrella over every heavy FetchContent library (mongocxx_static, bsoncxx_static, mongoc_static, bson_static, fmt, spdlog, opus, uvgrtp, whisper, ggml, the OTel exporter/sdk targets, gtest_main, gmock_main). Target names verified against \`ninja -t targets all\` in an existing build.
- Wraps the two \`add_executable\` calls in \`if (EXISTS …/main.cpp)\` / \`tests/server/TestGlobals.cpp\` guards. Lets Phase 1 cmake configure succeed when src/ + tests/ aren't populated yet.

**Dockerfile** — split into two phases:
- **Phase 1** (deps): COPY cmake/ lib/ externals/ + CMakeLists.txt + build_oatpp.sh + the one Version.h.in template configure_file() needs. Build oatpp, cmake configure (with empty src/), \`ninja deps_only\`. This whole layer only invalidates when one of those inputs changes.
- **Phase 2** (project): COPY src/ tests/. Re-run cmake (so \`file(GLOB)\` re-evaluates) then \`ninja\`. Picks up pre-compiled dep .a files from Phase 1; only the project's own .cpp files compile.

**All 4 workflows** (tests.yml, amd64.yml, arm64.yml, debian-package.yml) now use docker/build-push-action with \`cache-from: type=gha\` + \`cache-to: type=gha,mode=max\`. Scopes are per-target (amd64/arm64/package-\$os) so the matrix jobs don't trample each other's cache. tests.yml swapped from raw \`docker build\` to \`docker/build-push-action\` with \`load: true\` so the subsequent \`docker run\` still works.

## Local validation

| | wall clock |
|---|---|
| Fresh \`docker build\` from scratch | 4m26s |
| Incremental rebuild (touched one .cpp) | 1m54s ← Phase 1 layer cached |
| Expected first CI run (no GHA cache yet) | ~5 min |
| Expected typical PR build after that | ~2 min |

Was ~15 min per CI build before.

## Things I considered + didn't do

- **ccache** (issue #13 option 3): biggest win for big PRs but more moving parts (buildx cache mount + path mapping). Skipped per April's earlier scope choice; can be a follow-up if even Phase 2's incremental compile feels slow.
- **Storage facade refactor** (issue #11): unrelated; that's a follow-up to the multichar-dialogue PR.

## Test plan

- [ ] Merge → first CI run on main populates the GHA cache (~5 min).
- [ ] Second CI run after a trivial source change should drop to ~2 min.
- [ ] Verify all 4 workflows (tests, amd64, arm64, debian-package) still produce their expected artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)