### PR TITLE
ci: stop uploading .dockerbuild build-record artifacts

### DIFF
--- a/.github/workflows/amd64.yml
+++ b/.github/workflows/amd64.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  # docker/build-push-action uploads a .dockerbuild build-record artifact per
+  # run by default. They're only consumed by the buildx history debug UI and
+  # piled up (hundreds) against the Actions storage quota. Disable the upload.
+  DOCKER_BUILD_RECORD_UPLOAD: false
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  # docker/build-push-action uploads a .dockerbuild build-record artifact per
+  # run by default. They're only consumed by the buildx history debug UI and
+  # piled up (hundreds) against the Actions storage quota. Disable the upload.
+  DOCKER_BUILD_RECORD_UPLOAD: false
+
 jobs:
   build:
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -5,6 +5,10 @@ on: [push, pull_request]
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: RelWithDebInfo
+  # docker/build-push-action uploads a .dockerbuild build-record artifact per
+  # run by default. They're only consumed by the buildx history debug UI and
+  # piled up (hundreds) against the Actions storage quota. Disable the upload.
+  DOCKER_BUILD_RECORD_UPLOAD: false
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
     branches: [ "main" ]
 
 env:
+  # docker/build-push-action uploads a .dockerbuild build-record artifact per
+  # run by default. They're only consumed by the buildx history debug UI and
+  # piled up (hundreds) against the Actions storage quota. Disable the upload.
+  DOCKER_BUILD_RECORD_UPLOAD: false
   CTEST_EXCLUDE: >-
     mongoc/fixtures/fake_kms_provider_server/start|
     mongoc/CMake/bare-bson-import|


### PR DESCRIPTION
## What

Set `DOCKER_BUILD_RECORD_UPLOAD: false` on all four workflows that use `docker/build-push-action` (`amd64`, `arm64`, `debian-package`, `tests`).

## Why

`docker/build-push-action` uploads a `.dockerbuild` build-record artifact on every run by default. These are only consumed by the `buildx history` debug UI, and they'd accumulated into the hundreds — 375 live records (~63 MB), plus many more expired — eating the account-level Actions storage quota. Already cleaned up the existing ones; this stops them coming back.

## Safety

- **Does not touch the `type=gha` layer cache** (separate storage system, `/actions/caches`). The heavy C++ deps-layer cache that keeps builds at ~2 min is untouched — verified 126 caches still present.
- Only disables the build-record *artifact* upload; `cache-from`/`cache-to` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)