### PR TITLE
Docs: require a GitHub Issue for every feature/bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,9 @@ This file provides Claude Code-specific guidance and workflow tips for this repo
 
 ## Workflow
 
+### Commit Signing (YubiKey)
+Commits are signed with a YubiKey, and the touch prompt times out. If `git commit` fails with `Couldn't sign message (signer): agent refused operation`, **tell April to touch the YubiKey when its light flashes**, then retry the exact same commit — it succeeds once the key is touched.
+
 ### GitHub Issues for Features and Bugs (Required)
 **When starting work on a feature or bug, open a GitHub Issue first** (`gh issue create`) and use it for tracking and notes — GitHub Issues play the role Jira does on a professional team:
 - Capture the symptom, investigation notes, and root cause in the issue as you learn them — the issue is the durable record of *why*, not just *what*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,15 @@ This file provides Claude Code-specific guidance and workflow tips for this repo
 3. **Test command**: `cd build && ./creature-server-test`
 4. **Code format**: Always run `clang-format` on modified C++ files
 
+## Workflow
+
+### GitHub Issues for Features and Bugs (Required)
+**When starting work on a feature or bug, open a GitHub Issue first** (`gh issue create`) and use it for tracking and notes — GitHub Issues play the role Jira does on a professional team:
+- Capture the symptom, investigation notes, and root cause in the issue as you learn them — the issue is the durable record of *why*, not just *what*
+- Reference the issue from commits and PRs (`Fixes #N` / `Refs #N`) so the fix links back to the analysis
+- Close it when the fix lands on `main`
+- The same rule applies to the console repo (creature-console)
+
 ## Tool Usage Guidelines
 
 ### When to Use the Task Tool with Explore Agent


### PR DESCRIPTION
Adds the new workflow rule to CLAUDE.md: open a GitHub Issue when starting work on any feature or bug, keep investigation/root-cause notes in it, link commits and PRs with `Fixes #N`, and close it when the fix lands on `main`. GitHub Issues serve as the Jira equivalent for personal projects. The matching rule was added to creature-console's CLAUDE.md as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)